### PR TITLE
Add aocec improvements from @Raybuntu

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
+++ b/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
@@ -752,7 +752,6 @@
 	};
 	aocec: aocec{
 		compatible = "amlogic, amlogic-aocec";
-		device_name = "aocec";
 		status = "okay";
 		vendor_name = "WeTek"; /* Max Chars: 8     */
 		vendor_id = <0x000000>; /* Refer to http://standards.ieee.org/develop/regauth/oui/oui.txt   */

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -1234,6 +1234,13 @@ int cec_node_init(struct hdmitx_dev *hdmitx_device)
 		return -1;
 	}
 
+	if (wait_event_interruptible(hdmitx_device->hdmi_info.vsdb_phy_addr.waitq,
+		hdmitx_device->hdmi_info.vsdb_phy_addr.valid == 1))
+	{
+		CEC_INFO("error during wait for a valid physical address\n");
+		return -ERESTARTSYS;
+	}
+
 	a = hdmitx_device->hdmi_info.vsdb_phy_addr.a;
 	b = hdmitx_device->hdmi_info.vsdb_phy_addr.b;
 	c = hdmitx_device->hdmi_info.vsdb_phy_addr.c;
@@ -1816,6 +1823,13 @@ static struct class_attribute aocec_class_attr[] = {
 /******************** cec hal interface ***************************/
 static int hdmitx_cec_open(struct inode *inode, struct file *file)
 {
+	if (wait_event_interruptible(cec_dev->tx_dev->hdmi_info.vsdb_phy_addr.waitq,
+		cec_dev->tx_dev->hdmi_info.vsdb_phy_addr.valid == 1))
+	{
+		CEC_INFO("error during wait for a valid physical address\n");
+		return -ERESTARTSYS;
+	}
+
 	cec_dev->cec_info.open_count++;
 	if (cec_dev->cec_info.open_count) {
 		cec_dev->cec_info.hal_ctl = 1;

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -971,6 +971,8 @@ static void cec_pre_init(void)
 	}
 	ao_cec_init();
 
+	cec_config(cec_dev->tx_dev->cec_func_config, 1);
+
 	cec_arbit_bit_time_set(3, 0x118, 0);
 	cec_arbit_bit_time_set(5, 0x000, 0);
 	cec_arbit_bit_time_set(7, 0x2aa, 0);
@@ -1834,10 +1836,6 @@ static int hdmitx_cec_open(struct inode *inode, struct file *file)
 	cec_dev->cec_info.open_count++;
 	if (cec_dev->cec_info.open_count) {
 		cec_dev->cec_info.hal_ctl = 1;
-		/* enable all cec features */
-		cec_config(0x2f, 1);
-		/* set default logical addr flag for uboot */
-		cec_set_reg_bits(AO_DEBUG_REG1, 0xf, 16, 4);
 	}
 	return 0;
 }
@@ -1847,9 +1845,6 @@ static int hdmitx_cec_release(struct inode *inode, struct file *file)
 	cec_dev->cec_info.open_count--;
 	if (!cec_dev->cec_info.open_count) {
 		cec_dev->cec_info.hal_ctl = 0;
-		/* disable all cec features */
-		cec_config(0x0, 1);
-		cec_set_reg_bits(AO_DEBUG_REG1, 0xf, 16, 4);
 	}
 	return 0;
 }

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -1887,7 +1887,12 @@ static ssize_t hdmitx_cec_write(struct file *f, const char __user *buf,
 		return -EINVAL;
 
 	ret = cec_ll_tx(tempbuf, size);
-	return ret;
+	if (ret == CEC_FAIL_NACK) {
+		return -1;
+	}
+	else {
+		return size;
+	}
 }
 
 static void init_cec_port_info(struct hdmi_port_info *port,

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -237,12 +237,12 @@ unsigned int aocec_rd_reg(unsigned long addr)
 {
 	unsigned int data32;
 	unsigned long flags;
-	waiting_aocec_free();
 	spin_lock_irqsave(&cec_dev->cec_reg_lock, flags);
+	waiting_aocec_free();
 	data32 = 0;
 	data32 |= 0 << 16; /* [16]	 cec_reg_wr */
 	data32 |= 0 << 8; /* [15:8]   cec_reg_wrdata */
-	data32 |= addr << 0; /* [7:0]	cec_reg_addr */
+	data32 |= (addr & 0xff) << 0; /* [7:0]	cec_reg_addr */
 	writel(data32, cec_dev->cec_reg + AO_CEC_RW_REG);
 
 	waiting_aocec_free();
@@ -253,15 +253,16 @@ unsigned int aocec_rd_reg(unsigned long addr)
 
 void aocec_wr_reg(unsigned long addr, unsigned long data)
 {
-	unsigned long data32;
+	unsigned int data32;
 	unsigned long flags;
-	waiting_aocec_free();
 	spin_lock_irqsave(&cec_dev->cec_reg_lock, flags);
+	waiting_aocec_free();
 	data32 = 0;
 	data32 |= 1 << 16; /* [16]	 cec_reg_wr */
-	data32 |= data << 8; /* [15:8]   cec_reg_wrdata */
-	data32 |= addr << 0; /* [7:0]	cec_reg_addr */
+	data32 |= (data & 0xff) << 8; /* [15:8]   cec_reg_wrdata */
+	data32 |= (addr & 0xff) << 0; /* [7:0]	cec_reg_addr */
 	writel(data32, cec_dev->cec_reg + AO_CEC_RW_REG);
+	waiting_aocec_free();
 	spin_unlock_irqrestore(&cec_dev->cec_reg_lock, flags);
 } /* aocec_wr_only_reg */
 

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -155,27 +155,27 @@ static unsigned char msg_log_buf[128] = { 0 };
 
 #define HR_DELAY(n)     (ktime_set(0, n * 1000 * 1000))
 __u16 cec_key_map[160] = {
-    KEY_ENTER, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, 0 , 0 , 0 ,//0x00
-    0 , KEY_HOMEPAGE , KEY_MENU, 0, 0, KEY_BACK, 0, 0,
-    0 , 0, 0, 0, 0, 0, 0, 0,//0x10
-    0 , 0, 0, 0, 0, 0, 0, 0,
-    KEY_0 , KEY_1, KEY_2, KEY_3,KEY_4, KEY_5, KEY_6, KEY_7,//0x20
-    KEY_8 , KEY_9, KEY_DOT, 0, 0, 0, 0, 0,
-    KEY_CHANNELUP , KEY_CHANNELDOWN, KEY_CHANNEL, 0, 0, 0, 0, 0,//0x30
-    0 , 0, 0, 0, 0, 0, 0, 0,
+	KEY_ENTER, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, 0 , 0 , 0 ,//0x00
+	0 , KEY_HOMEPAGE , KEY_MENU, 0, 0, KEY_BACK, 0, 0,
+	0 , 0, 0, 0, 0, 0, 0, 0,//0x10
+	0 , 0, 0, 0, 0, 0, 0, 0,
+	KEY_0 , KEY_1, KEY_2, KEY_3,KEY_4, KEY_5, KEY_6, KEY_7,//0x20
+	KEY_8 , KEY_9, KEY_DOT, 0, 0, 0, 0, 0,
+	KEY_CHANNELUP , KEY_CHANNELDOWN, KEY_CHANNEL, 0, 0, 0, 0, 0,//0x30
+	0 , 0, 0, 0, 0, 0, 0, 0,
 
-    KEY_POWER , KEY_VOLUMEUP, KEY_VOLUMEDOWN, KEY_MUTE, KEY_PLAYPAUSE, KEY_STOP, KEY_PLAYPAUSE, KEY_RECORD,//0x40
-    KEY_REWIND, KEY_FASTFORWARD, KEY_EJECTCD, KEY_NEXTSONG, KEY_PREVIOUSSONG, 0, 0, 0,
-    0 , 0, 0, KEY_PROGRAM, 0, 0, 0, 0,//0x50
-    0 , 0, 0, 0, 0, 0, 0, 0,
-    KEY_PLAYCD, KEY_PLAYPAUSE, KEY_RECORD, KEY_PAUSECD, KEY_STOPCD, KEY_MUTE, 0, KEY_TUNER,//0x60
-    0 , KEY_MEDIA, 0, 0, KEY_POWER, 0, 0, 0,
-    0 , KEY_BLUE, KEY_RED, KEY_GREEN, KEY_YELLOW, 0, 0, 0,//0x70
-    0 , 0, 0, 0, 0, 0, 0, 0x2fd,
-    0 , 0, 0, 0, 0, 0, 0, 0,//0x80
-    0 , 0, 0, 0, 0, 0, 0, 0,
-    0 , KEY_EXIT, 0, 0, 0, 0, KEY_PVR, 0,//0x90  //samsung vendor buttons return and channel_list
-    0 , 0, 0, 0, 0, 0, 0, 0,
+	KEY_POWER , KEY_VOLUMEUP, KEY_VOLUMEDOWN, KEY_MUTE, KEY_PLAYPAUSE, KEY_STOP, KEY_PLAYPAUSE, KEY_RECORD,//0x40
+	KEY_REWIND, KEY_FASTFORWARD, KEY_EJECTCD, KEY_NEXTSONG, KEY_PREVIOUSSONG, 0, 0, 0,
+	0 , 0, 0, KEY_PROGRAM, 0, 0, 0, 0,//0x50
+	0 , 0, 0, 0, 0, 0, 0, 0,
+	KEY_PLAYCD, KEY_PLAYPAUSE, KEY_RECORD, KEY_PAUSECD, KEY_STOPCD, KEY_MUTE, 0, KEY_TUNER,//0x60
+	0 , KEY_MEDIA, 0, 0, KEY_POWER, 0, 0, 0,
+	0 , KEY_BLUE, KEY_RED, KEY_GREEN, KEY_YELLOW, 0, 0, 0,//0x70
+	0 , 0, 0, 0, 0, 0, 0, 0x2fd,
+	0 , 0, 0, 0, 0, 0, 0, 0,//0x80
+	0 , 0, 0, 0, 0, 0, 0, 0,
+	0 , KEY_EXIT, 0, 0, 0, 0, KEY_PVR, 0,//0x90  //samsung vendor buttons return and channel_list
+	0 , 0, 0, 0, 0, 0, 0, 0,
 };
 
 struct hrtimer cec_key_timer;
@@ -183,43 +183,43 @@ static int last_key_irq = -1;
 static int key_value = 1;
 enum hrtimer_restart cec_key_up(struct hrtimer *timer)
 {
-    if (key_value == 1){
-        input_event(cec_dev->cec_info.remote_cec_dev,
-            EV_KEY, cec_key_map[last_key_irq], 0);
-    }
-    input_sync(cec_dev->cec_info.remote_cec_dev);
-    CEC_INFO("last:%d up\n", cec_key_map[last_key_irq]);
-    key_value = 2;
+	if (key_value == 1){
+		input_event(cec_dev->cec_info.remote_cec_dev,
+		EV_KEY, cec_key_map[last_key_irq], 0);
+	}
+	input_sync(cec_dev->cec_info.remote_cec_dev);
+	CEC_INFO("last:%d up\n", cec_key_map[last_key_irq]);
+	key_value = 2;
 
-    return HRTIMER_NORESTART;
+	return HRTIMER_NORESTART;
 }
 
 void cec_user_control_pressed_irq(unsigned char message_irq)
 {
-    if (message_irq < 160) {
-        CEC_INFO("Key pressed: %d\n", message_irq);
-        input_event(cec_dev->cec_info.remote_cec_dev, EV_KEY,
-                cec_key_map[message_irq], key_value);
-        input_sync(cec_dev->cec_info.remote_cec_dev);
-        last_key_irq = message_irq;
-        hrtimer_start(&cec_key_timer, HR_DELAY(200), HRTIMER_MODE_REL);
-        CEC_INFO(":key map:%d\n", cec_key_map[message_irq]);
-    }
+	if (message_irq < 160) {
+		CEC_INFO("Key pressed: %d\n", message_irq);
+		input_event(cec_dev->cec_info.remote_cec_dev, EV_KEY,
+				cec_key_map[message_irq], key_value);
+		input_sync(cec_dev->cec_info.remote_cec_dev);
+		last_key_irq = message_irq;
+		hrtimer_start(&cec_key_timer, HR_DELAY(200), HRTIMER_MODE_REL);
+		CEC_INFO(":key map:%d\n", cec_key_map[message_irq]);
+	}
 }
 
 void cec_user_control_released_irq(void)
 {
-    /*
-     * key must be valid
-     */
-    if (last_key_irq != -1) {
-        CEC_INFO("Key released: %d\n",last_key_irq);
-        hrtimer_cancel(&cec_key_timer);
-        input_event(cec_dev->cec_info.remote_cec_dev,
-            EV_KEY, cec_key_map[last_key_irq], 0);
-        input_sync(cec_dev->cec_info.remote_cec_dev);
-        key_value = 1;
-    }
+	/*
+	 * key must be valid
+	 */
+	if (last_key_irq != -1) {
+		CEC_INFO("Key released: %d\n",last_key_irq);
+		hrtimer_cancel(&cec_key_timer);
+		input_event(cec_dev->cec_info.remote_cec_dev,
+				EV_KEY, cec_key_map[last_key_irq], 0);
+		input_sync(cec_dev->cec_info.remote_cec_dev);
+		key_value = 1;
+	}
 }
 
 void cec_set_reg_bits(unsigned int addr, unsigned int value,
@@ -1351,15 +1351,15 @@ static void cec_rx_process(void)
 	opcode = msg[1];
 	switch (opcode) {
 	case CEC_OC_ACTIVE_SOURCE:
-		if (wake_ok == 0) {
-			int phy_addr = msg[2] << 8 | msg[3];
-			if (phy_addr == 0xffff)
-				break;
-			wake_ok = 1;
-			phy_addr |= (initiator << 16);
-			writel(phy_addr, cec_dev->cec_reg + AO_RTI_STATUS_REG1);
-			CEC_INFO("found wake up source:%x", phy_addr);
-		}
+		//if (wake_ok == 0) {
+		//	int phy_addr = msg[2] << 8 | msg[3];
+		//	if (phy_addr == 0xffff)
+		//		break;
+		//	wake_ok = 1;
+		//	phy_addr |= (initiator << 16);
+		//	writel(phy_addr, cec_dev->cec_reg + AO_RTI_STATUS_REG1);
+		//	CEC_INFO("found wake up source:%x", phy_addr);
+		//}
 		break;
 
 	case CEC_OC_GET_CEC_VERSION:
@@ -1517,8 +1517,8 @@ static void cec_task(struct work_struct *work)
 	int ret;
 
 	dwork = &cec_dev->cec_work;
-	if (cec_dev && !wake_ok &&
-	   !(cec_dev->hal_flag & (1 << HDMI_OPTION_SYSTEM_CEC_CONTROL))) {
+	if (cec_dev &&
+			!(cec_dev->hal_flag & (1 << HDMI_OPTION_SYSTEM_CEC_CONTROL))) {
 		if (1 << cec_dev->cec_info.log_addr & (1 << 0x0 | 1 << 0xF)) {
 			ret = cec_node_init(cec_dev->tx_dev);
 			if (ret < 0) {
@@ -1887,6 +1887,8 @@ static ssize_t hdmitx_cec_write(struct file *f, const char __user *buf,
 		return -EINVAL;
 
 	ret = cec_ll_tx(tempbuf, size);
+	/* delay a byte for continue message send */
+	msleep(25);
 	if (ret == CEC_FAIL_NACK) {
 		return -1;
 	}

--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -66,7 +66,7 @@ static struct early_suspend aocec_suspend_handler;
 #include <linux/amlogic/jtag.h>
 
 #define CEC_FRAME_DELAY		msecs_to_jiffies(400)
-#define CEC_DEV_NAME		"cec"
+#define CEC_DEV_NAME		"aocec"
 
 #define DEV_TYPE_TV			0
 #define DEV_TYPE_RECORDER		1

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_edid.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_edid.c
@@ -1746,7 +1746,7 @@ int hdmitx_edid_parse(struct hdmitx_dev *hdmitx_device)
 
 	edid_save_checkvalue(EDID_buf, BlockCount+1);
 
-#if 1
+#if 0
 	i = hdmitx_edid_dump(hdmitx_device, (char *)(hdmitx_device->tmp_buf),
 		HDMI_TMP_BUF_SIZE);
 	hdmitx_device->tmp_buf[i] = 0;

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_edid.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_edid.c
@@ -318,6 +318,9 @@ static void set_vsdb_phy_addr(struct vsdb_phyaddr *vsdb,
 	vsdb->d = (edid_offset[5] >> 0) & 0xf;
 	vsdb_local = *vsdb;
 	vsdb->valid = 1;
+#ifdef CONFIG_AML_AO_CEC
+	wake_up_interruptible(&vsdb->waitq);
+#endif
 }
 
 static void set_vsdb_dc_cap(struct rx_cap *pRXCap,

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -3104,6 +3104,8 @@ static  int __init hdmitx_boot_para_setup(char *s)
 	char *token;
 	unsigned token_len, token_offset, offset = 0;
 	int size = strlen(s);
+	unsigned long list;
+	int ret = 0;
 
 	do {
 		token = next_token_ex(separator, s, size, offset,
@@ -3112,6 +3114,12 @@ static  int __init hdmitx_boot_para_setup(char *s)
 		if ((token_len == 3)
 			&& (strncmp(token, "off", token_len) == 0)) {
 			init_flag |= INIT_FLAG_NOT_LOAD;
+		} else if (strncmp(token, "cec", 3) == 0) {
+			ret = kstrtoul(token+3, 16, &list);
+			if ((list >= 0) && (list <= 0xff))
+				hdmitx_device.cec_func_config = list;
+			hdmi_print(IMP, CEC "HDMI hdmi_cec_func_config:0x%x\n",
+				   hdmitx_device.cec_func_config);
 		}
 	}
 		offset = token_offset;

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -2763,6 +2763,9 @@ static int amhdmitx_probe(struct platform_device *pdev)
 	HDMITX_Meson_Init(&hdmitx_device);
 	hdmitx_device.task = kthread_run(hdmi_task_handle,
 		&hdmitx_device, "kthread_hdmi");
+#ifdef CONFIG_AML_AO_CEC
+	init_waitqueue_head(&hdmitx_device.hdmi_info.vsdb_phy_addr.waitq);
+#endif
 
 	if (r < 0) {
 		hdmi_print(INF, SYS "register switch dev failed\n");

--- a/include/linux/amlogic/hdmi_tx/hdmi_info_global.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_info_global.h
@@ -19,6 +19,7 @@
 #define _HDMI_INFO_GLOBAL_H
 
 #include "hdmi_common.h"
+#include <linux/wait.h>
 
 /* old definitions move to hdmi_common.h */
 
@@ -269,6 +270,9 @@ struct vsdb_phyaddr {
 	unsigned char c:4;
 	unsigned char d:4;
 	unsigned char valid;
+#ifdef CONFIG_AML_AO_CEC
+	wait_queue_head_t waitq;
+#endif
 };
 
 struct hdmitx_clk {

--- a/include/linux/amlogic/hdmi_tx/hdmi_tx_cec_20.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_tx_cec_20.h
@@ -333,6 +333,7 @@ void cec_arbit_bit_time_set(unsigned , unsigned , unsigned);
 void cec_clear_buf(unsigned int flag);
 void cec_keep_reset(void);
 void cec_logicaddr_set(int logicaddr);
+void cec_logicaddr_clear(void);
 void ao_cec_init(void);
 void tx_irq_handle(void);
 
@@ -340,6 +341,17 @@ unsigned int cec_config(unsigned int value, bool wr_flag);
 unsigned int cec_intr_stat(void);
 unsigned int cec_phyaddr_config(unsigned int value, bool wr_flag);
 unsigned int cec_logicaddr_config(unsigned int value, bool wr_flag);
+int  cec_node_init(struct hdmitx_dev *hdmitx_device);
+void cec_polling_online_dev(int log_addr, int *bool);
+void cec_imageview_on_smp(void);
+void cec_get_menu_language_smp(void);
+
+void cec_user_control_pressed_irq(unsigned char message_irq);
+void cec_user_control_released_irq(void);
+extern __u16 cec_key_map[160];
+void cec_active_source_smp(void);
+void cec_send_simplink_alive(void);
+void cec_send_simplink_ack(void);
 
 extern bool cec_msg_dbg_en;
 extern struct cec_global_info_t cec_info;


### PR DESCRIPTION
This adds aocec improvements cherry-picked from https://github.com/Raybuntu/linux/commits/hdmi_ao_cec

Removing `device_name` from device-tree fixes an issue with systemd-journald not starting.
Disabling hdmitx_edid_dump prevents a recoverable crash and stack-trace in kernel log.

Please do not merge until fully tested.
