### PR TITLE
Add Odroid C2 support

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -182,6 +182,12 @@ config ARCH_XGENE
 	help
 	  This enables support for AppliedMicro X-Gene SOC Family
 
+config ARCH_MESON64_ODROIDC2
+        bool "Hardkernel's ODROID-C2 board"
+        help
+          This enables support for the board ODROID-C2 of Hardkernel
+          which is based on ARMv8 SoC of AMLogic, Inc.
+
 endmenu
 
 menu "Bus support"

--- a/arch/arm64/boot/dts/Makefile
+++ b/arch/arm64/boot/dts/Makefile
@@ -2,6 +2,7 @@ dtb-$(CONFIG_ARCH_VEXPRESS) += rtsm_ve-aemv8a.dtb foundation-v8.dtb \
 				fvp-base-gicv2-psci.dtb
 dtb-$(CONFIG_ARCH_XGENE) += apm-mustang.dtb
 dtb-$(CONFIG_ARCH_VEXPRESS) += juno.dtb
+dtb-$(CONFIG_ARCH_MESON64_ODROIDC2) += meson64_odroidc2.dtb
 
 targets += dtbs
 

--- a/arch/arm64/boot/dts/meson64_odroidc2.dts
+++ b/arch/arm64/boot/dts/meson64_odroidc2.dts
@@ -1,0 +1,853 @@
+/*
+ * AMLogic's S905 based ODROID-C2 board device tree source
+ *
+ * Copyright (c) 2015 Hardkernel Co., Ltd.
+ *                    http://www.hardkernel.com
+ *
+ * Device tree source file for Hardkernel's ODROID-C2 board based on AMLogic's
+ * S905 SoC.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/clock/gxbb.h>
+#include <dt-bindings/gpio/gxbb.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/reset/aml_gxbb.h>
+#include "amlogic/mesongxbb.dtsi"
+/ {
+	model = "ODROID-C2";
+	amlogic-dt-id = "odroidc2_2g";
+	compatible = "amlogic, Gxbb";
+	interrupt-parent = <&gic>;
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	aliases {
+		serial0 = &uart_AO;
+		serial1 = &uart_A;
+	};
+
+	gpu_dvfs_tbl:gpu_dvfs_tbl {
+		sc_mpp = <3>;/* number of pp used most of time.*/
+		tbl = <&clk285_cfg &clk400_cfg &clk500_cfg &clk666_cfg &clk800_cfg>;
+	};
+
+	memory@00000000 {
+		device_type = "memory";
+		linux,usable-memory = <0x0 0x1000000 0x0 0x7f000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		/* global autoconfigured region for contiguous allocations */
+		secmon_reserved:linux,secmon {
+			compatible = "amlogic, aml_secmon_memory";
+			reg = <0x0 0x10000000 0x0 0x200000>;
+			no-map;
+		};
+		secos_reserved:linux,secos {
+			status = "disable";
+			compatible = "amlogic, aml_secos_memory";
+			reg = <0x0 0x05300000 0x0 0x2000000>;
+			no-map;
+		};
+		pstore:aml_pstore {
+			compatible = "amlogic, pstore";
+			reg = <0x0 0x07300000 0x0 0x100000>;
+			no-map;
+		};
+		fb_reserved:linux,meson-fb {
+			compatible = "amlogic, fb-memory";
+			size = <0x0 0x1900000>;
+			no-map;
+		};
+
+		di_reserved:linux,di {
+			compatible = "amlogic, di-mem";
+			size = <0x0 0x1e00000>; //10x1920x1088x3/2=30M
+			//no-map;
+			multi-use;
+		};
+
+		ion_reserved:linux,ion-dev {
+			compatible = "amlogic, idev-mem";
+			size = <0x0 0x2000000>;
+			multi-use;
+		};
+
+		/*  POST PROCESS MANAGER */
+		ppmgr_reserved:linux,ppmgr {
+			compatible = "amlogic, ppmgr_memory";
+			size = <0x0 0x0>;
+			multi-use;
+		};
+
+		codec_mm_cma:linux,codec_mm_cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			size = <0x0 0xc000000>;
+			alignment = <0x0 0x400000>;
+			linux,contiguous-region;
+		};
+		picdec_cma_reserved:linux,picdec {
+			compatible = "shared-dma-pool";
+			reusable;
+			size = <0x0 0x0>;
+			status = "disabled";
+			alignment = <0x0 0x400000>;
+			linux,contiguous-region;
+		};
+		/* codec shared reserved */
+		codec_mm_reserved:linux,codec_mm_reserved {
+			compatible = "amlogic, codec-mm-reserved";
+			size = <0x0 0x4100000>;
+			alignment = <0x0 0x100000>;
+ 			//no-map;
+		};
+	};
+
+	meson-vout {
+		compatible = "amlogic, meson-vout";
+		dev_name = "meson-vout";
+		status = "okay";
+	};
+	meson-fb {
+		compatible = "amlogic, meson-fb";
+		memory-region = <&fb_reserved>;
+		dev_name = "meson-fb";
+		status = "okay";
+		interrupts = <0 3 1
+			0 89 1>;
+		interrupt-names = "viu-vsync", "rdma";
+		mem_size = <0x01800000 0x00100000>; /* fb0/fb1 memory size */
+		display_mode_default = "1080p60hz";
+		scale_mode = <1>; /** 0:VPU free scale 1:OSD free scale 2:OSD super scale */
+		display_size_default = <1920 1080 1920 2160 32>; //1920*1080*4*3 = 0x17BB000
+	};
+	ge2d {
+		compatible = "amlogic, ge2d";
+		dev_name = "ge2d";
+		status = "okay";
+		interrupts = <0 150 1>;
+		interrupt-names = "ge2d";
+		clocks = <&clock CLK_VAPB_0>,
+			<&clock CLK_GE2D>;
+		clock-names = "clk_vapb_0",
+				"clk_ge2d";
+		resets = <&clock GCLK_IDX_GE2D>;
+		reset-names = "ge2d";
+	};
+	codec_io {
+		compatible = "amlogic, codec_io";
+		#address-cells=<2>;
+		#size-cells=<2>;
+		ranges;
+		io_cbus_base{
+			reg = <0x0 0xC1100000 0x0 0x100000>;
+		};
+		io_dos_base{
+			reg = <0x0 0xc8820000 0x0 0x10000>;
+		};
+		io_hiubus_base{
+			reg = <0x0 0xc883c000 0x0 0x2000>;
+		};
+		io_aobus_base{
+			reg = <0x0 0xc8100000 0x0 0x100000>;
+		};
+		io_vcbus_base{
+			reg = <0x0 0xd0100000 0x0 0x40000>;
+		};
+		io_dmc_base{
+			reg = <0x0 0xc8838000 0x0 0x400>;
+		};
+	};
+	codec_mm {
+			compatible = "amlogic, codec, mm";
+			memory-region = <&codec_mm_cma &codec_mm_reserved>;
+			dev_name = "codec_mm";
+			status = "okay";
+	};
+	ethmac: ethernet@0xc9410000{
+                compatible = "amlogic, gxbb-rgmii-dwmac";
+                reg = <0x0 0xc9410000 0x0 0x10000
+                0x0 0xc8834540 0x0 0x8>;
+                interrupts = <0 8 1>;
+                phy-mode= "rgmii";
+                pinctrl-names = "eth_pins";
+                pinctrl-0 = <&eth_pins>;
+                rst_pin-gpios = <&gpio GPIOZ_14 0>;
+                mc_val = <0x1621>;
+                resets = <&clock GCLK_IDX_ETHERNET>;
+                reset-names = "ethpower";
+                interrupt-names = "macirq";
+                clocks = <&clock CLK_81>;
+                clock-names = "ethclk81";
+        };
+
+	pwm {
+		compatible = "amlogic, gx-pwm";
+		status = "okay";
+		pwm-outputs = <0>,<1>,<2>,<3>,<4>,<5>,<6>,<7>;
+		reg = <0x0 0xc1108550 0x0 0x30>,
+				<0x0 0xc8100550 0x0 0x10>;
+		clocks = <&clock CLK_XTAL>,
+				<&clock CLK_VID_PLL>,
+				<&clock CLK_FPLL_DIV4>,
+				<&clock CLK_FPLL_DIV3>;
+		clock-names = "xtal",
+				"vid_pll_clk",
+				"fclk_div4",
+				"fclk_div3";
+		clock-select = <0x0>,<0x0>,<0x0>,<0x0>,<0x3>,<0x0>,<0x0>,<0x0>;
+	};
+
+	mesonstream {
+		compatible = "amlogic, codec, streambuf";
+		dev_name = "mesonstream";
+		status = "okay";
+		resets = <&clock GCLK_IDX_HIU_PARSER_TOP
+			&clock GCLK_IDX_VPU_INTR
+			&clock GCLK_IDX_DEMUX
+			&clock GCLK_IDX_DOS>;
+		reset-names = "parser_top",
+			"vpu_intr",
+			"demux",
+			"vdec";
+	};
+
+	amvideocap {
+		compatible = "amlogic, amvideocap";
+		dev_name = "amvideocap.0";
+		status = "okay";
+		max_size = <8>;//8M
+	};
+
+	ion_dev {
+		compatible = "amlogic, ion_dev";
+		memory-region = <&ion_reserved>;
+	};
+
+	vdec {
+		compatible = "amlogic, vdec";
+		dev_name = "vdec.0";
+		status = "okay";
+		interrupts = <0 3 1
+			0 23 1
+			0 32 1
+			0 43 1
+			0 44 1
+			0 45 1>;
+		interrupt-names = "vsync",
+			"demux",
+			"parser",
+			"mailbox_0",
+			"mailbox_1",
+			"mailbox_2";
+	};
+	picdec {
+		   compatible = "amlogic, picdec";
+		   memory-region = <&picdec_cma_reserved>;
+		   dev_name = "picdec";
+		   status = "okay";
+	};
+	ppmgr {
+		compatible = "amlogic, ppmgr";//to match of_device_id's compatible member
+		memory-region = <&ppmgr_reserved>;
+		dev_name = "ppmgr";
+		status = "okay";
+	};
+	deinterlace {
+		compatible = "amlogic, deinterlace";
+		status = "okay";
+		memory-region = <&di_reserved>;
+		interrupts = <0 46 1
+				0 6 1>;
+		interrupt-names = "de_irq",
+				"timerc";
+		buffer-size = <3133440>;	//1920x1088x3/2
+		hw-version = <2>;
+	};
+
+	amvdec_656in0 {
+		compatible = "amlogic, amvdec_656in";
+		dev_name = "amvdec_656in0";
+		status = "ok";
+		reg = <0x0 0xd0048000 0x0 0x7c>;
+		clocks = <&clock CLK_FPLL_DIV2>,
+			<&clock CLK_BT656_CLK0>;
+		clock-names = "fclk_div2", "cts_bt656_clk0";
+		bt656_id = <0>;
+	};
+	amvdec_656in1 {
+		compatible = "amlogic, amvdec_656in";
+		dev_name = "amvdec_656in1";
+		status = "ok";
+		reg = <0x0 0xd0050000 0x0 0x7c>;
+		clocks = <&clock CLK_FPLL_DIV2>,
+			<&clock CLK_BT656_CLK1>;
+		clock-names = "fclk_div2", "cts_bt656_clk1";
+		bt656_id = <1>;
+	};
+
+	amvenc_avc{
+		compatible = "amlogic, amvenc_avc";
+		//memory-region = <&amvenc_avc_reserved>;
+		dev_name = "amvenc_avc";
+		status = "okay";
+		interrupts = <0 45 1>;
+		interrupt-names = "mailbox_2";
+	};
+
+	vpu {
+		compatible = "amlogic, vpu";
+		dev_name = "vpu";
+		status = "ok";
+		clk_level = <7>;
+		/**	0: 100.0M    1: 166.7M    2: 200.0M
+			3: 250.0M    4: 333.3M    5: 400.0M
+			6: 500.0M    7: 666.7M */
+	};
+
+    sd{
+        compatible = "amlogic, aml_sd_emmc";
+        dev_name = "aml_newsd.0";
+        status = "okay";
+        reg = <0x0 0xd0072000 0x0 0x2000>;
+        interrupts = <	0 217 1
+        				0 67 1
+        				0 69 1>;
+        pinctrl-names = "sd_clk_cmd_pins", "sd_all_pins", "sd_1bit_pins","sd_clk_cmd_uart_pins","sd_1bit_uart_pins", "sd_to_ao_uart_pins", "ao_to_sd_uart_pins","ao_to_sd_jtag_pins","sd_to_ao_jtag_pins";
+        pinctrl-0 = <&sd_clk_cmd_pins>;
+        pinctrl-1 = <&sd_all_pins>;
+        pinctrl-2 = <&sd_1bit_pins>;
+        pinctrl-3 = <&sd_clk_cmd_uart_pins>;
+        pinctrl-4 = <&sd_1bit_uart_pins>;
+        pinctrl-5 = <&sd_to_ao_uart_pins>;
+        pinctrl-6 = <&ao_to_sd_uart_pins>;
+        pinctrl-7 = <&ao_to_sd_jtag_pins>;
+        pinctrl-8 = <&sd_to_ao_jtag_pins>;
+
+		sd{
+	   		status = "okay";
+	   		pinname = "sd";
+	   		ocr_avail = <0x00200080>; // 3.3:0x200000, 1.8+3.3:0x00200080
+	   		caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED",
+					"MMC_CAP_SD_HIGHSPEED";
+					//"MMC_CAP_UHS_SDR12",
+					//"MMC_CAP_UHS_SDR25","MMC_CAP_UHS_SDR50",
+					//"MMC_CAP_UHS_SDR104";
+	   		f_min = <400000>;
+	   		f_max = <100000000>;
+	   		max_req_size = <0x20000>;          /**128KB*/
+			gpio_dat3 = <&gpio       CARD_4       GPIO_ACTIVE_HIGH>;
+			jtag_pin =  <&gpio       CARD_0       GPIO_ACTIVE_HIGH>;
+			gpio_cd =  <&gpio       CARD_6       GPIO_ACTIVE_HIGH>;
+			/*if card have no switch gpio, remove all relative to vol_switch */
+			vol_switch =  <&gpio_ao       GPIOAO_3       GPIO_ACTIVE_LOW>;
+			vol_switch_18 = <1>; /* 1 = high, 0 = low */
+			vol_switch_delay = <150>; /* Uint: ms*/
+	   		irq_in = <3>;
+	   		irq_out = <5>;
+	   		card_type = <5>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
+		};
+    };
+    emmc{
+        compatible = "amlogic, aml_sd_emmc";
+        dev_name = "aml_newsd.0";
+        status = "okay";
+        reg = <0x0 0xd0074000 0x0 0x2000>;
+        interrupts = <	0 218 1>;
+        pinctrl-names = "emmc_clk_cmd_pins", "emmc_all_pins";
+        pinctrl-0 = <&emmc_clk_cmd_pins>;
+        pinctrl-1 = <&emmc_all_pins>;
+        emmc{
+            status = "okay";
+            pinname = "emmc";
+            ocr_avail = <0x200080>;          /**VDD voltage 3.3 ~ 3.4 */
+            caps = "MMC_CAP_8_BIT_DATA","MMC_CAP_MMC_HIGHSPEED",
+			"MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE","MMC_CAP_1_8V_DDR",
+			"MMC_CAP_HW_RESET", "MMC_CAP_ERASE", "MMC_CAP_CMD23";
+                        caps2 = "MMC_CAP2_HS200_1_8V_SDR",
+                              "MMC_CAP2_HS400_1_8V",
+                              "MMC_CAP2_BROKEN_VOLTAGE",
+                              "MMC_CAP2_BOOTPART_NOACC";
+                        f_min = <400000>;
+                        f_max = <100000000>;
+			tx_phase = <0>;
+            max_req_size = <0x20000>;          /**256KB*/
+//            gpio_dat3 = "BOOT_3"
+		gpio_dat3 = <&gpio       BOOT_3      GPIO_ACTIVE_HIGH>;
+		hw_reset =  <&gpio       BOOT_9      GPIO_ACTIVE_HIGH>;
+            card_type = <1>; /* 1:mmc card(include eMMC), 2:sd card(include tSD), */
+		};
+    };
+
+	amhdmitx: amhdmitx{
+		compatible = "amlogic, amhdmitx";
+		dev_name = "amhdmitx";
+		status = "okay";
+		pinctrl-names="hdmitx_hpd", "hdmitx_ddc";
+		pinctrl-0=<&hdmitx_hpd>;
+		pinctrl-1=<&hdmitx_ddc>;
+		/* HPD, 57 + 32 = 89; CEC, 151 + 32 = 183*/
+		interrupts = <0 57 1>;
+		interrupt-names = "hdmitx_hpd";
+		clocks = <&clock CLK_HDMITX_SYS &clock CLK_HDMITX_ENCP
+			&clock CLK_HDMITX_ENCI &clock CLK_HDMITX_PIXEL
+			&clock CLK_HDMITX_PHY &clock CLK_VID>;
+		clock-names = "hdmitx_clk_sys", "hdmitx_clk_encp", "hdmitx_clk_enci",
+			"hdmitx_clk_pixel", "hdmitx_clk_phy", "hdmitx_clk_vid";
+		ranges;
+		#address-cells = <2>;
+		#size-cells = <2>;
+	};
+	aocec: aocec{
+		compatible = "amlogic, amlogic-aocec";
+		status = "okay";
+		vendor_name = "Hardkernel"; /* Max Chars: 8     */
+		vendor_id = <0x000000>; /* Refer to http://standards.ieee.org/develop/regauth/oui/oui.txt   */
+		product_desc = "ODROID-C2"; /* Max Chars: 16    */
+		cec_osd_string = "ODROID-C2"; /* Max Chars: 14    */
+		port_num = <1>;
+		arc_port_mask = <0x0>;
+		interrupts = <0 199 1>;
+		interrupt-names = "hdmi_aocec";
+		pinctrl-names = "hdmitx_aocec";
+		pinctrl-0=<&hdmitx_aocec>;
+		reg = <0x0 0xc810023c 0x0 0x4
+		       0x0 0xc8100000 0x0 0x200>;
+	};
+
+	tvout {
+		compatible = "amlogic, tvout";
+		dev_name = "tvout";
+		status = "okay";
+	};
+
+	uart_AO: serial@c81004c0 {
+		compatible = "amlogic, meson-uart";
+		reg = <0x0 0xc81004c0 0x0 0x14>;
+		interrupts = <0 193 1>;
+		status = "okay";
+		clocks = <&clock CLK_XTAL>;
+		clock-names = "clk_uart";
+		fifosize = < 64 >;
+		pinctrl-names = "default";
+		//pinctrl-0 = <&ao_uart_pins>;
+		support-sysrq = <0>;	/* 0 not support , 1 support */
+	};
+	uart_A: serial@c11084c0 {
+		compatible = "amlogic, meson-uart";
+		reg = <0x0 0xc11084c0 0x0 0x14>;
+		interrupts = <0 26 1>;
+		status = "okay";
+		clocks = <&clock CLK_XTAL>;
+		clock-names = "clk_uart";
+		fifosize = < 128 >;
+		pinctrl-names = "default";
+		pinctrl-0 = <&a_uart_pins>;
+		resets = <&clock GCLK_IDX_UART0>;
+	};
+
+
+	canvas{
+		compatible = "amlogic, meson, canvas";
+		dev_name = "amlogic-canvas";
+		status = "ok";
+		reg = <0x0 0xc8838000 0x0 0x400>;
+	};
+
+	rdma{
+		compatible = "amlogic, meson, rdma";
+		dev_name = "amlogic-rdma";
+		status = "ok";
+		interrupts = <0 89 1>;
+		interrupt-names = "rdma";
+	};
+
+	dwc2_b {
+		compatible = "amlogic,dwc2";
+		device_name = "dwc2_b";
+		reg = <0x0 0xc9100000 0x0 0x40000>;
+		interrupts = <0 31 4>;
+		status = "okay";
+		pl-periph-id = <1>; /** lm name */
+		clock-src = "usb1"; /** clock src */
+		port-id = <1>;   /** ref to mach/usb.h */
+		port-type = <1>;	/** 0: otg, 1: host, 2: slave */
+		port-speed = <0>; /** 0: default, 1: high, 2: full */
+		port-config = <0>; /** 0: default */
+		port-dma = <0>; /** 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
+		port-id-mode = <1>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		gpio-hub-rst = "GPIOAO_4";
+		gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+		phy-reg = <0xc0000020>;
+		phy-reg-size = <0x20>;
+		usb-fifo = <1024>;
+		host-only-core = <1>;
+		pmu-apply-power = <1>;
+		cpu-type = "gxbaby";
+		resets = <&clock GCLK_IDX_USB_GENERAL
+					&clock GCLK_IDX_MISC_USB1_TO_DDR
+					&clock GCLK_IDX_USB1>;
+		reset-names = "usb_general",
+						"usb1",
+						"usb1_to_ddr";
+	};
+
+	odroid_sysfs {
+		compatible = "odroid-sysfs";
+	};
+
+	dwc2_a {
+		compatible = "amlogic,dwc2";
+		device_name = "dwc2_a";
+		reg = <0x0 0xc9000000 0x0 0x40000>;
+		interrupts = <0 30 4>;
+		status = "okay";
+		pl-periph-id = <0>; /** lm name */
+		clock-src = "usb0"; /** clock src */
+		port-id = <0>;  /** ref to mach/usb.h */
+		port-type = <0>;	/** 0: otg, 1: host, 2: slave */
+		port-speed = <0>; /** 0: default, high, 1: full */
+		port-config = <0>; /** 0: default */
+		port-dma = <0>; /** 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		gpio-vbus-power = "GPIOAO_5";
+		gpios = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
+		gpio-work-mask	= <1>; /**0: work on pulldown,1:work on pullup*/
+		phy-reg = <0xc0000000>;
+		phy-reg-size = <0x20>;
+		usb-fifo = <1024>;
+		cpu-type = "gxbaby";
+		resets = <&clock GCLK_IDX_USB_GENERAL
+					    &clock GCLK_IDX_MISC_USB0_TO_DDR
+              &clock GCLK_IDX_USB0>;
+		reset-names = "usb_general",
+						"usb0",
+						"usb0_to_ddr";
+	};
+
+	/* AUDIO MESON8 DEVICES */
+	i2s_dai: I2S {
+		#sound-dai-cells = <0>;
+		resets = <
+			&clock GCLK_IDX_AIU_AI_TOP_GLUE
+			&clock GCLK_IDX_AUD_BUF_ABD
+			&clock GCLK_IDX_AIU_I2S_OUT
+			&clock GCLK_IDX_AIU_AMCLK_MEASURE
+			&clock GCLK_IDX_AIU_AIFIFO2
+			&clock GCLK_IDX_AIU_AUD_MIXER
+			&clock GCLK_IDX_AIU_MIXER_REG
+			&clock GCLK_IDX_AIU_ADC
+			&clock GCLK_IDX_AIU_TOP_LEVEL
+			&clock GCLK_IDX_AIU_AOCLK
+			&clock GCLK_IDX_AUD_IN
+		>;
+		reset-names =
+			"top_glue",
+			"aud_buf",
+			"i2s_out",
+			"amclk_measure",
+			"aififo2",
+			"aud_mixer",
+			"mixer_reg",
+			"adc",
+			"top_level",
+			"aoclk",
+			"aud_in";
+		clocks = <&clock CLK_MPLL0>,
+			<&clock CLK_AMCLK>;
+		clock-names = "mpll0", "mclk";
+		compatible = "amlogic, aml-i2s-dai";
+	};
+	spdif_dai: SPDIF {
+		#sound-dai-cells = <0>;
+		compatible = "amlogic, aml-spdif-dai";
+		resets = <
+			&clock GCLK_IDX_AIU_IEC958
+			&clock GCLK_IDX_AIU_ICE958_AMCLK
+		>;
+		reset-names =
+			"iec958",
+			"iec958_amclk";
+		clocks = <&clock CLK_MPLL1>,
+			<&clock CLK_I958>,
+			<&clock CLK_AMCLK>,
+			<&clock CLK_SPDIF>,
+			<&clock CLK_81>;
+		clock-names = "mpll1", "i958", "mclk", "spdif", "clk_81";
+	};
+	pcm_dai: PCM {
+		#sound-dai-cells = <0>;
+		compatible = "amlogic, aml-pcm-dai";
+		pinctrl-names = "aml_audio_btpcm";
+		pinctrl-0 = <&audio_btpcm_pins>;
+	};
+	i2s_plat: i2s_platform {
+		compatible = "amlogic, aml-i2s";
+		interrupts = <0 29 1>;
+	};
+	pcm_plat: pcm_platform {
+		compatible = "amlogic, aml-pcm";
+	};
+	spdif_codec: spdif_codec {
+		#sound-dai-cells = <0>;
+		compatible = "amlogic, aml-spdif-codec";
+		device_name = "dummy-spdif-dit.0";
+		pinctrl-names = "aml_audio_spdif";
+		pinctrl-0 = <&audio_spdif_pins>;
+	};
+	pcm_codec: pcm_codec{
+		#sound-dai-cells = <0>;
+		compatible = "amlogic, pcm2BT-codec";
+	};
+	/* endof AUDIO MESON8 DEVICES */
+
+	/* AUDIO board specific */
+	dummy_codec:dummy{
+		#sound-dai-cells = <0>;
+		compatible = "amlogic, aml_dummy_codec";
+		status = "okay";
+	};
+	aml_m8_snd {
+		compatible = "aml, aml_snd_m8";
+		status = "okay";
+		aml-sound-card,format = "i2s";
+		aml_sound_card,name = "AML-M8AUDIO";
+		aml,audio-routing =
+				"Ext Spk","LOUTL",
+				"Ext Spk","LOUTR";
+
+		mute_gpio-gpios = <&gpio GPIOH_3 0>;
+		hp_disable;
+		hp_paraments = <800 300 0 5 1>;
+		pinctrl-names = "aml_snd_m8";
+		pinctrl-0 = <&audio_pins>;
+		cpu_list = <&cpudai0 &cpudai1 &cpudai2>;
+		codec_list = <&codec0 &codec1 &codec2>;
+		plat_list = <&i2s_plat &i2s_plat &pcm_plat>;
+		cpudai0: cpudai0 {
+			sound-dai = <&i2s_dai>;
+		};
+		cpudai1: cpudai1 {
+			sound-dai = <&spdif_dai>;
+		};
+		cpudai2: cpudai2 {
+			sound-dai = <&pcm_dai>;
+		};
+		codec0: codec0 {
+			sound-dai = <&dummy_codec>;
+		};
+		codec1: codec1 {
+			sound-dai = <&spdif_codec>;
+		};
+		codec2: codec2 {
+			sound-dai = <&pcm_codec>;
+		};
+	};
+	/* END OF AUDIO board specific */
+
+	gpio_keypad{
+	    compatible = "amlogic, gpio_keypad";
+		status = "okay";
+		scan_period = <20>;
+		key_num = <1>;
+	    key_name = "power";
+		key_code = <116>;
+		key_pin = <&gpio_ao  GPIOAO_3  GPIO_ACTIVE_HIGH>;  /*"GPIOAO_3";*/
+	    irq_keyup = <6>;
+	    irq_keydown = <7>;
+	};
+
+	adc_keypad{
+		compatible = "amlogic, adc_keypad";
+		status = "okay";
+		key_name = "menu", "vol-","vol+", "esc", "home";
+		key_num = <5>;
+		key_code = <139 114 115 1 102>;
+		key_chan = <0 0 0 0 0>;
+		key_val = <0 143 271 393 510>; //voltage=0/252/478/692/824mV, val=voltage/1800mV*1023
+		key_tolerance = <40 40 40 40 40>;
+	};
+
+	aml_sensor0: aml-sensor@0 {
+		compatible = "amlogic, aml-thermal";
+		device_name = "thermal";
+		#thermal-sensor-cells = <1>;
+		cooling_devices {
+			cpufreq_cool_cluster0 {
+				min_state = <1000000>;
+				dyn_coeff = <140>;
+				cluster_id = <0>;
+				node_name = "cpus";
+				device_type = "cpufreq";
+			};
+			cpucore_cool_cluster0 {
+				min_state = <1>;
+				dyn_coeff = <0>;
+				cluster_id = <0>;
+				node_name = "cpu_core_cluster0";
+				device_type = "cpucore";
+			};
+			gpufreq_cool {
+				min_state = <400>;
+				dyn_coeff = <437>;
+				cluster_id = <0>;
+				node_name = "mali";
+				device_type = "gpufreq";
+			};
+			gpucore_cool {
+				min_state = <1>;
+				dyn_coeff = <0>;
+				cluster_id = <0>;
+				node_name = "thermal_gpu_cores";
+				device_type = "gpucore";
+			};
+		};
+		cpu_cluster0:cpu_core_cluster0 {
+			#cooling-cells = <2>; /* min followed by max */
+		};
+		gpucore:thermal_gpu_cores {
+			#cooling-cells = <2>; /* min followed by max */
+		};
+	};
+	thermal-zones {
+		soc_thermal {
+			polling-delay = <1000>;
+			polling-delay-passive = <100>;
+			sustainable-power = <2150>;
+
+			thermal-sensors = <&aml_sensor0 3>;
+
+			trips {
+				switch_on: trip-point@0 {
+					temperature = <70000>;
+					hysteresis = <1000>;
+					type = "passive";
+				};
+				control: trip-point@1 {
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "passive";
+				};
+				hot: trip-point@2 {
+					temperature = <85000>;
+					hysteresis = <5000>;
+					type = "hot";
+				};
+				critical: trip-point@3 {
+					temperature = <260000>;
+					hysteresis = <1000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				cpufreq_cooling_map {
+					trip = <&control>;
+					cooling-device = <&cpus 0 4>;
+					contribution = <1024>;
+				};
+				cpucore_cooling_map {
+					trip = <&control>;
+					cooling-device = <&cpu_cluster0 0 3>;
+					contribution = <1024>;
+				};
+				gpufreq_cooling_map {
+					trip = <&control>;
+					cooling-device = <&gpu 0 4>;
+					contribution = <1024>;
+				};
+				gpucore_cooling_map {
+					trip = <&control>;
+					cooling-device = <&gpucore 0 2>;
+					contribution = <1024>;
+				};
+			};
+		};
+	};
+
+	saradc: saradc {
+		compatible = "amlogic, saradc";
+		status = "okay";
+		interrupts = <0 9 1>;
+		interrupt-names = "saradc_int";
+		clocks = <&clock CLK_XTAL>;
+		clock-names = "saradc_clk";
+                reg = <0x0 0xc1108680 0x0 0x30
+                        0x0 0xc883c3d8 0x0 0x08>;
+	};
+
+        leds: gpio_leds {
+                compatible = "gpio-leds";
+
+		pinctrl-names = "led_pins";
+		pinctrl-0 = <&led_pins>;
+
+                /* Blue LED */
+                heartbeat {
+                        label = "blue:heartbeat";
+                        gpios = <&gpio_ao GPIOAO_13 GPIO_ACTIVE_LOW>;
+                        linux,default-trigger = "heartbeat";
+                };
+        };
+};
+&i2c_a {
+  status = "disabled";
+  /*p200: multiplex with usb PWR, disbaled*/
+};
+/*
+&i2c_b {
+  status = "okay";
+};
+*/
+
+&i2c_slave {
+	status = "disabled";
+};
+&pinmux {
+	audio_pins:audio_pin{
+		amlogic,setmask=<AO 0x78000000>;
+		amlogic,clrmask=<AO 0x40000>;
+		amlogic,pins = "GPIOAO_8","GPIOAO_9","GPIOAO_10","GPIOAO_11";
+	};
+
+	audio_spdif_pins:audio_pin1{
+		amlogic,setmask=<AO 0x10000>;	/*spdif_out*/
+		amlogic,clrmask=<AO 0x40000>;	/*spdif_out*/
+		amlogic,pins ="GPIOAO_6";		/*spdif_out*/
+	};
+
+	audio_btpcm_pins:audio_btpcm_pins{
+		/* BT PCM PINMUX SETTING*/
+		amlogic,setmask=<3 0x78000000>;
+		amlogic,clrmask=<3 0x803280
+				4 0xc0>;
+		amlogic,pins ="GPIOX_8", "GPIOX_9", "GPIOX_10", "GPIOX_11";
+	};
+
+        led_pins: led_pin {
+                amlogic,setmask = <AO 0x00000>;
+                amlogic,clrmask = <AO 0x80000018>;
+                amlogic,pins = "GPIOAO_13";
+        };
+};
+
+&efuse {
+	status = "okay";
+};
+&audio_data{
+	status = "okay";
+};
+&meson_ir {
+	status = "okay";
+};

--- a/drivers/amlogic/usb/dwc_otg/310/dwc_otg_driver.c
+++ b/drivers/amlogic/usb/dwc_otg/310/dwc_otg_driver.c
@@ -1006,6 +1006,22 @@ static int dwc_otg_driver_probe(struct platform_device *pdev)
 					gpio_work_mask = of_read_ulong(prop, 1);
 			}
 
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+			gpio_name = of_get_property(of_node,
+						"gpio-hub-rst", NULL);
+			if (gpio_name) {
+				struct gpio_desc *hub_gd =
+					gpiod_get_index(&pdev->dev, NULL, 0);
+				if (IS_ERR(hub_gd))
+					return -1;
+
+				gpiod_direction_output(hub_gd, 0);
+				mdelay(20);
+				gpiod_direction_output(hub_gd, 1);
+				mdelay(20);
+				gpiod_put(hub_gd);
+			}
+#endif
 			prop = of_get_property(of_node, "host-only-core", NULL);
 			if (prop)
 				host_only_core = of_read_ulong(prop, 1);

--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -45,7 +45,9 @@
 #include <asm/uaccess.h>
 
 #include "queue.h"
+#if !defined(CONFIG_ARCH_MESON64_ODROIDC2)
 #include <linux/mmc/emmc_partitions.h>
+#endif
 
 MODULE_ALIAS("mmc:block");
 #ifdef MODULE_PARAM_PREFIX
@@ -2486,7 +2488,9 @@ static int mmc_blk_probe(struct mmc_card *card)
 	if (mmc_add_disk(md))
 		goto out;
 
+#if !defined(CONFIG_ARCH_MESON64_ODROIDC2)
 	aml_emmc_partition_ops(card, md->disk); /* add by gch */
+#endif
 
 	list_for_each_entry(part_md, &md->part, part) {
 		if (mmc_add_disk(part_md))


### PR DESCRIPTION
This adds a device tree for Odroid C2 and patches to fix USB and eMMC.

See https://github.com/LibreELEC/LibreELEC.tv/pull/744 for LE related PR.
