### PR TITLE
Add sysfs node to force RGB output

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -1759,6 +1759,20 @@ void hdmi_print(int dbg_lvl, const char *fmt, ...)
 	}
 }
 
+static ssize_t store_output_rgb(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	if (strncmp(buf, "1", 1) == 0)
+		hdmitx_output_rgb();
+
+	hdmitx_set_display(&hdmitx_device, hdmitx_device.cur_VIC);
+
+	return count;
+}
+
+static DEVICE_ATTR(output_rgb, S_IWUSR | S_IWGRP,
+	NULL, store_output_rgb);
+
 static DEVICE_ATTR(disp_mode, S_IWUSR | S_IRUGO | S_IWGRP,
 	show_disp_mode, store_disp_mode);
 static DEVICE_ATTR(aud_mode, S_IWUSR | S_IRUGO, show_aud_mode,
@@ -2624,6 +2638,7 @@ static int amhdmitx_probe(struct platform_device *pdev)
 	ret = device_create_file(dev, &dev_attr_ready);
 	ret = device_create_file(dev, &dev_attr_support_3d);
 	ret = device_create_file(dev, &dev_attr_dc_cap);
+	ret = device_create_file(dev, &dev_attr_output_rgb);
 #ifdef CONFIG_AML_VOUT_FRAMERATE_AUTOMATION
 	register_hdmi_edid_supported_func(hdmitx_is_vmode_supported);
 #endif
@@ -2816,6 +2831,7 @@ static int amhdmitx_remove(struct platform_device *pdev)
 	device_remove_file(dev, &dev_attr_vic);
 	device_remove_file(dev, &dev_attr_hdcp_pwr);
 	device_remove_file(dev, &dev_attr_aud_output_chs);
+	device_remove_file(dev, &dev_attr_output_rgb);
 
 	cdev_del(&hdmitx_device.cdev);
 

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_video.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_video.c
@@ -622,6 +622,8 @@ int hdmitx_set_display(struct hdmitx_dev *hdmitx_device,
 		param->color = param->color_prefer;
 		if (hdmi_output_rgb) {
 			param->color = COLORSPACE_RGB444;
+			hdmitx_device->para->cs =
+				hdmitx_device->cur_video_param->color;
 		} else {
 			/* HDMI CT 7-24 Pixel Encoding
 			 * YCbCr to YCbCr Sink


### PR DESCRIPTION
These patches add a sysfs node that allows to force RGB output by `echo 1 > /sys/class/amhdmitx/amhdmitx0/output_rgb`

This is needed for some older Philips TVs that incorrectly report supported colour space which results in pink/green screen.

Patches have been tested on my generic S905 builds:
https://forum.libreelec.tv/thread-1129-post-13917.html#pid13917
