### PR TITLE
arm64: el0_dbg does not set link reg for return to user path, breaks …

### DIFF
--- a/arch/arm64/kernel/entry.S
+++ b/arch/arm64/kernel/entry.S
@@ -571,6 +571,7 @@ el0_dbg:
 	disable_step x1
 	mov	x1, x25
 	mov	x2, sp
+	adr	lr, ret_from_exception
 	b	do_debug_exception
 el0_inv:
 	enable_dbg


### PR DESCRIPTION
…debug

patch cherry-picked from https://github.com/hardkernel/linux/commit/845f2e4781d2182e82a9235b7a744e888716ea80

right now, running anything under gdb (gdb --args /path/to/program --arg1 --arg...) results in an immediate gdb segfault

with this patch I was able to succesfuly run kodi under gdb, or attach gdb to already runing kodi process

note that this is not a complete fix. debugging is still broken if hardware watchpoints are enabled:

```
CONFIG_PERF_EVENTS=y
CONFIG_HAVE_HW_BREAKPOINT=y
CONFIG_AMLOGIC_WATCHPOINT=y
```

with hw watchpoints enabled in kernel config, I was able to debug a simple program, but starting kodi in gdb (gdb --args /usr/lib/kodi/kodi.bin -fs ..) still fails (startup takes forever). however, LE builds wetek_hub and wetek_play2 projects without CONFIG_PERF_EVENTS. odroid c2 defconfig (if odroid project is using this amlogic kernel) may need to be adjusted..
