### PR TITLE
Fix Odroid C2 DTS entry to support HK RTC Shield

### DIFF
--- a/arch/arm64/boot/dts/meson64_odroidc2.dts
+++ b/arch/arm64/boot/dts/meson64_odroidc2.dts
@@ -802,8 +802,15 @@
         };
 };
 &i2c_a {
-  status = "disabled";
-  /*p200: multiplex with usb PWR, disbaled*/
+    status = "okay";
+
+    /* Hardkernel I2C RTC */
+    pcf8563: pcf8563@51    {
+        status = "okay";
+        compatible = "nxp,pcf8563";
+        reg = <0x51>;
+        #clock-cells = <0>;
+    };
 };
 /*
 &i2c_b {


### PR DESCRIPTION
Commit fixes this issue:

https://forum.libreelec.tv/thread-1602.html

I'm not sure if status="okay" in the pcf8563 node has any downsides? HK sets it to disabled and lets the user enable it with:
`fdtput -t s meson64_odroidc2.dtb /i2c@c1108500/pcf8563@51 status "okay"`
Since we don't have that tool inside LE I was thinking about setting in in boot.ini but it doesn't work.
