### PR TITLE
kernel/power: workaround for Android PM sequence

### DIFF
--- a/kernel/power/main.c
+++ b/kernel/power/main.c
@@ -362,6 +362,9 @@ static ssize_t state_store(struct kobject *kobj, struct kobj_attribute *attr,
 			error = 0;
 			request_suspend_state(state);
 		}
+		if (state == PM_SUSPEND_MEM) {
+			msleep_interruptible(5000);
+		}
 #else
 		error = pm_suspend(state);
 #endif


### PR DESCRIPTION
Suspend sequence in Android kernel is:
1. Suspend -> return 0 (userspace not aware of Android sequence thinks system is already up)
2. Call Early suspend handlers
3. Really suspend

At step 2 userspace is already calling wakeup handlers. To prevent e.g. re-loading modules
before actual suspend and in result preventing it, we need to delay returning a little.

Making suspend work on devices using `dhd` wireless module requires adding it to `/etc/suspend-modules.conf`
