### PR TITLE
arch/arm64/boot/dts/amlogic: use meson-ir on wetek hub

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
+++ b/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
@@ -1208,6 +1208,6 @@
 &defendkey {
 	status = "okay";
 };
-&aml_remote {
+&meson_ir {
 	status = "okay";
 };


### PR DESCRIPTION
Changes WeTek Hub device tree to use meson-ir instead of amremote

https://github.com/LibreELEC/LibreELEC.tv/pull/820