### PR TITLE
drivers/amlogic/amports: use error_recovery_mode = 1 for H264

### DIFF
--- a/drivers/amlogic/amports/vh264.c
+++ b/drivers/amlogic/amports/vh264.c
@@ -244,7 +244,7 @@ static bool check_pts_discontinue;
 static u32 wait_buffer_counter;
 static u32 video_signal_from_vui;
 
-static uint error_recovery_mode;
+static uint error_recovery_mode = 1;
 static uint error_recovery_mode_in = 3;
 static uint error_recovery_mode_use = 3;
 

--- a/drivers/amlogic/amports/vh264_4k2k.c
+++ b/drivers/amlogic/amports/vh264_4k2k.c
@@ -100,7 +100,7 @@ static u32 saved_resolution;
 static struct timer_list recycle_timer;
 static u32 stat;
 static u32 error_watchdog_count;
-static uint error_recovery_mode;
+static uint error_recovery_mode = 1;
 static u32 sync_outside;
 static u32 vh264_4k2k_rotation;
 static u32 first_i_recieved;


### PR DESCRIPTION
After a recent kernel update from Amlogic error in H264 stream results in picture stuttering even if stream goes back to normal. This is a big issue for DVB with low signal level. **error_recovery_mode = 1** results in a few macroblock artifacts on error and stream stays smooth.

Tested by @codesnake, 2 users that reported the issue and me. Should be good to go.