### PR TITLE
Fix framerate automation when amlvideo is included into VFM map

### DIFF
--- a/drivers/amlogic/video_dev/amlvideo.c
+++ b/drivers/amlogic/video_dev/amlvideo.c
@@ -337,6 +337,13 @@ static int video_receiver_event_fun(int type, void *data, void *private_data)
 						NULL);
 		}
 	}
+        else if (type == VFRAME_EVENT_PROVIDER_FR_HINT) {
+		vf_notify_receiver(PROVIDER_NAME,VFRAME_EVENT_PROVIDER_FR_HINT,data);
+        }
+	else if (type == VFRAME_EVENT_PROVIDER_FR_END_HINT) {
+    		vf_notify_receiver(PROVIDER_NAME,VFRAME_EVENT_PROVIDER_FR_END_HINT,data);
+        }
+
 	return 0;
 }
 


### PR DESCRIPTION
This PR makes framerate automation in AML kernel 3.14 to function properly with Kodi 17 Krypton.