### PR TITLE
Ensure the IEEE HDMI identifier is set even when the EDID cannot be read

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx.c
@@ -1311,6 +1311,12 @@ wait:
                 if(!(hdmitx_device->HWOp.CntlDDC(hdmitx_device, DDC_IS_EDID_DATA_READY, 0))) {
                     hdmi_print(ERR, EDID "edid failed\n");
                     hdmitx_device->tv_no_edid = 1;
+                    hdmi_print(ERR, EDID "setting HDMI vendor\n");
+                    hdmitx_device->HWOp.CntlConfig(hdmitx_device, CONF_HDMI_DVI_MODE, HDMI_MODE);
+                    hdmitx_device->RXCap.IEEEOUI = 0x000c03; /* Need to stop us being switched in to DVI mode */
+                    set_disp_mode_auto();
+                    hdmi_print(ERR, EDID "manual cec now\n");
+                    cec_node_init(hdmitx_device);
                 }
                 else {
                     goto edid_op;


### PR DESCRIPTION
We had a Vero 2 user with an HDMI cable that was most likely faulty. The result was that the device could not read an EDID. When this is the case, it is possible to force a video mode, however the current hdmi_tx codepath will result in the IEEE HDMI identifier not being set. This means that audio will not work, as the display will effectively be configured for DVI mode.

The following patch resolves the issue. It changes the default behaviour. We assume that if we cannot read the EDID after two attempts, we should still configure the display for HDMI mode. We will also try and bring up CEC. This was tested on a DVI display and does not cause regressions, provided that it is functioning correctly. Note, that if no HPD event is detected, the display will still be configured in DVI mode.

It would help this user here for example: https://forum.libreelec.tv/thread-200-post-3993.html#pid3993  
 