### PR TITLE
905 fps fix

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
@@ -59,7 +59,7 @@
 			clkp_freq = <500000000>;
 			voltage = <1150>;
 			keep_count = <5>;
-			threshold = <30 250>;
+			threshold = <30 120>;
 		  };
 
 		  clk250_cfg:clk250_cfg {
@@ -68,8 +68,7 @@
 			clkp_freq = <500000000>;
 			voltage = <1150>;
 			keep_count = <5>;
-			threshold = <115 250>;
-			/*125 = 250*(125/250), 50= 60-10*/
+			threshold = <80 170>;
 		  };
 
 		  clk285_cfg:clk285_cfg {
@@ -78,8 +77,7 @@
 			clkp_freq = <285000000>;
 			voltage = <1150>;
 			keep_count = <5>;
-			threshold = <100 250>;
-			/*109 = 250*(125/285)*/
+			threshold = <100 190>;
 		  };
 
 		  clk400_cfg:clk400_cfg {
@@ -87,9 +85,8 @@
 			clk_parent = "fclk_div5";
 			clkp_freq = <400000000>;
 			voltage = <1150>;
-			keep_count = <3>;
-			threshold = <168 250>;
-			/*178 = 250*(285/400)*/
+			keep_count = <5>;
+			threshold = <152 207>;
 		  };
 
 		  clk500_cfg:clk500_cfg {
@@ -97,9 +94,8 @@
 			clk_parent = "fclk_div4";
 			clkp_freq = <500000000>;
 			voltage = <1150>;
-			keep_count = <2>;
-			threshold = <190 250>;
-			/*200=250*(400/500)*/
+			keep_count = <5>;
+			threshold = <180 220>;
 		  };
 
 		  clk666_cfg:clk666_cfg {
@@ -107,9 +103,8 @@
 			clk_parent = "fclk_div3";
 			clkp_freq = <666000000>;
 			voltage = <1150>;
-			keep_count = <1>;
-			threshold = <177 250>;
-			/*187.5=250*(500/666.6)*/
+			keep_count = <5>;
+			threshold = <210 236>;
 		  };
 
 		  clk750_cfg:clk750_cfg {
@@ -117,9 +112,8 @@
 			clk_parent = "gp0_pll";
 			clkp_freq = <744000000>;
 			voltage = <1150>;
-			keep_count = <1>;
-			threshold = <213 255>;
-			/*223=250*(666.0/744.0), 223+7=230*/
+			keep_count = <5>;
+			threshold = <230 255>;
 		  };
 
 		  clk800_cfg:clk800_cfg {
@@ -127,7 +121,7 @@
 			clk_parent = "gp0_pll";
 			clkp_freq = <792000000>;
 			voltage = <1150>;
-			keep_count = <1>;
+			keep_count = <5>;
 			threshold = <230 255>;
 		  };
 

--- a/arch/arm64/boot/dts/amlogic/mesongxl-gpu-mali450.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxl-gpu-mali450.dtsi
@@ -1,0 +1,134 @@
+/*
+ * Amlogic GXL Platform gpu
+ *
+ * Copyright (c) 2015-2015 Amlogic Ltd
+ *
+ * This file is licensed under a dual GPLv2 or BSD license.
+ *
+ */
+
+/ {
+	gpu:mali@d00c0000{
+		#cooling-cells = <2>; /* min followed by max */
+		compatible = "arm,mali-450";
+		interrupt-parent = <&gic>;
+		reg = <0 0xd00c0000 0 0x40000>, /*mali APB bus base address*/
+		      <0 0xc883c000 0 0x01000>, /*hiubus base address for gpu clk cntl*/
+		      <0 0xc8100000 0 0x01000>, /*aobus  base address for gpu pmu domain*/
+		      <0 0xc883c000 0 0x01000>, /*hiubus base address for gpu clk cntl*/
+		      <0 0xc1104440 0 0x01000>;
+		interrupts = <0 160 4>, <0 161 4>, <0 162 4>, <0 163 4>,
+				   <0 164 4>, <0 165 4>, <0 166 4>, <0 167 4>,
+				   <0 168 4>, <0 169 4>;
+		interrupt-names = "IRQGP", "IRQGPMMU", "IRQPP", "IRQPMU",
+			"IRQPP0", "IRQPPMMU0", "IRQPP1", "IRQPPMMU1",
+			"IRQPP2", "IRQPPMMU2";
+		pmu_domain_config = <0x1 0x2 0x4 0x4 0x0 0x0 0x0 0x0 0x0 0x1 0x2 0x0>;
+		pmu_switch_delay = <0xffff> ;
+		num_of_pp = <3> ;
+		def_clk = <3> ;
+		sc_mpp = <3>;/* number of pp used most of time.*/
+		tbl = <&clk125_cfg &clk285_cfg &clk400_cfg &clk500_cfg &clk666_cfg &clk800_cfg>;
+
+		clocks = <&clock CLK_FPLL_DIV3>,
+			<&clock CLK_FPLL_DIV4>,
+			<&clock CLK_FPLL_DIV5>,
+			<&clock CLK_FPLL_DIV7>,
+			<&clock GP0_PLL>,
+			<&clock CLK_MALI>,
+			<&clock CLK_MALI_0>,
+			<&clock CLK_MALI_1>;
+		clock-names =
+			"fclk_div3",
+			"fclk_div4",
+			"fclk_div5",
+			"fclk_div7",
+			"gp0_pll",
+			"clk_mali",
+			"clk_mali_0",
+			"clk_mali_1";
+
+		  /*control_interval x keep_count == 900 - 1000ms */
+		  control_interval = <200>;
+
+		  clk125_cfg:clk125_cfg {
+			clk_freq = <125000000>;
+			clk_parent = "fclk_div4";
+			clkp_freq = <500000000>;
+			voltage = <1150>;
+			keep_count = <5>;
+			threshold = <30 250>;
+		  };
+
+		  clk250_cfg:clk250_cfg {
+			clk_freq = <250000000>;
+			clk_parent = "fclk_div4";
+			clkp_freq = <500000000>;
+			voltage = <1150>;
+			keep_count = <5>;
+			threshold = <115 250>;
+			/*125 = 250*(125/250), 50= 60-10*/
+		  };
+
+		  clk285_cfg:clk285_cfg {
+			clk_freq = <285000000>;
+			clk_parent = "fclk_div7";
+			clkp_freq = <285000000>;
+			voltage = <1150>;
+			keep_count = <5>;
+			threshold = <100 250>;
+			/*109 = 250*(125/285)*/
+		  };
+
+		  clk400_cfg:clk400_cfg {
+			clk_freq = <400000000>;
+			clk_parent = "fclk_div5";
+			clkp_freq = <400000000>;
+			voltage = <1150>;
+			keep_count = <3>;
+			threshold = <168 250>;
+			/*178 = 250*(285/400)*/
+		  };
+
+		  clk500_cfg:clk500_cfg {
+			clk_freq = <500000000>;
+			clk_parent = "fclk_div4";
+			clkp_freq = <500000000>;
+			voltage = <1150>;
+			keep_count = <2>;
+			threshold = <190 250>;
+			/*200=250*(400/500)*/
+		  };
+
+		  clk666_cfg:clk666_cfg {
+			clk_freq = <666000000>;
+			clk_parent = "fclk_div3";
+			clkp_freq = <666000000>;
+			voltage = <1150>;
+			keep_count = <1>;
+			threshold = <177 250>;
+			/*187.5=250*(500/666.6)*/
+		  };
+
+		  clk750_cfg:clk750_cfg {
+			clk_freq = <744000000>;
+			clk_parent = "gp0_pll";
+			clkp_freq = <744000000>;
+			voltage = <1150>;
+			keep_count = <1>;
+			threshold = <213 255>;
+			/*223=250*(666.0/744.0), 223+7=230*/
+		  };
+
+		  clk800_cfg:clk800_cfg {
+			clk_freq = <792000000>;
+			clk_parent = "gp0_pll";
+			clkp_freq = <792000000>;
+			voltage = <1150>;
+			keep_count = <1>;
+			threshold = <230 255>;
+		  };
+
+	};
+
+};/* end of / */

--- a/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
@@ -21,7 +21,7 @@
 #include <dt-bindings/reset/aml_gxl.h>
 #include <dt-bindings/thermal/thermal.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
-#include "mesongxbb-gpu-mali450.dtsi"
+#include "mesongxl-gpu-mali450.dtsi"
 / {
 	cpus:cpus {
 		#address-cells = <2>;


### PR DESCRIPTION
- This fixes a issue were S905 would get stuck at 30.3 fps after video playback or some GUI transitions when using a 60fps resolution.
- This also adds a unique DTSI for S905X because S905 DTSI will result in kernel crashes on S905X. 