### PR TITLE
Fix amltiming mpeg4 keyframe_pts_only

### DIFF
--- a/drivers/amlogic/amports/vmpeg4.c
+++ b/drivers/amlogic/amports/vmpeg4.c
@@ -349,7 +349,7 @@ static irqreturn_t vmpeg4_isr(int irq, void *dev_id)
 		}
 
 		if ((I_PICTURE == picture_type) ||
-				((P_PICTURE == picture_type) && (keyframe_pts_only != 0))) {
+				((P_PICTURE == picture_type) && (keyframe_pts_only == 0))) {
 			offset = READ_VREG(MP4_OFFSET_REG);
 			/*2500-->3000,because some mpeg4
 			video may checkout failed;


### PR DESCRIPTION
some issues resolved in mpeg4 and @peak3d's amltiming patches.

This is still WIP. Please do not merge yet. Please test before merge!!

See https://github.com/LibreELEC/LibreELEC.tv/pull/1178

3.10 PR: https://github.com/LibreELEC/linux-amlogic/pull/38