### PR TITLE
stmmac: Disable EEE to avoid rare network outage

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -2065,7 +2065,9 @@ static int stmmac_get_hw_features(struct stmmac_priv *priv)
 		priv->dma_cap.atime_stamp =
 		    (hw_cap & DMA_HW_FEAT_TSVER2SEL) >> 13;
 		/* 802.3az - Energy-Efficient Ethernet (EEE) */
-		priv->dma_cap.eee = (hw_cap & DMA_HW_FEAT_EEESEL) >> 14;
+		/* Disable EEE because it's causing network outage on WP2*/
+		//priv->dma_cap.eee = (hw_cap & DMA_HW_FEAT_EEESEL) >> 14;
+		priv->dma_cap.eee = 0;
 		priv->dma_cap.av = (hw_cap & DMA_HW_FEAT_AVSEL) >> 15;
 		/* TX and RX csum */
 		priv->dma_cap.tx_coe = (hw_cap & DMA_HW_FEAT_TXCOESEL) >> 16;


### PR DESCRIPTION
Fixes an issue on WP2 where Network disconnects unexpectedly on Gigabit networks.

This is not a fix but a workaround which disables EEE completely.
It's probably a good idea to fix revert that commit someday once the EEE
timer issue is found and fixed. Since I can't reproduce that issue myself it's best to disable EEE.

Thanks **@jester-xbmc** for finding that issue and doing all the research for a "fix".

Not sure if it's a proper fix. Maybe it's better to do a project specific patch in LE?
It should be tested before merge.
So far I did iperf3 tests. Speed is not effected as far I can tell and the connection is stable.

Reference:
https://forum.libreelec.tv/thread-3214-post-28570.html#pid28570
http://lists.infradead.org/pipermail/linux-amlogic/2016-November/001538.html
