### PR TITLE
media: rc: meson-ir: store raw event without processing

### DIFF
--- a/drivers/media/rc/meson-ir.c
+++ b/drivers/media/rc/meson-ir.c
@@ -98,7 +98,7 @@ static irqreturn_t meson_ir_irq(int irqno, void *dev_id)
 
 	rawir.pulse = !!(readl(ir->reg + IR_DEC_STATUS) & STATUS_IR_DEC_IN);
 
-	ir_raw_event_store_with_filter(ir->rc, &rawir);
+	ir_raw_event_store(ir->rc, &rawir);
 	ir_raw_event_handle(ir->rc);
 
 	spin_unlock(&ir->lock);


### PR DESCRIPTION
This PR fixes missed key pressed events when pressing remote buttons at a fast pace.

Only tested with NEC protocol, needs more testing with other protocols/remotes.