### PR TITLE
arch/arm64/boot/dts: update reserved memory allocation

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
+++ b/arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dts
@@ -52,8 +52,8 @@
 		};
 		pstore:aml_pstore {
 			compatible = "amlogic, pstore";
-			reg = <0x0 0x07300000 0x0 0x100000>;
-			no-map;
+			//reg = <0x0 0x07300000 0x0 0x100000>;
+			//no-map;
 		};
 		fb_reserved:linux,meson-fb {
 			compatible = "amlogic, fb-memory";
@@ -70,7 +70,7 @@
 
 		ion_reserved:linux,ion-dev {
 			compatible = "amlogic, idev-mem";
-			size = <0x0 0x2000000>;
+			//size = <0x0 0x2000000>;
 			multi-use;
 		};
 
@@ -87,16 +87,16 @@
 //			size = <0x0 0x01000000>;
 //		};
 		/*  POST PROCESS MANAGER */
-		//ppmgr_reserved:linux,ppmgr {
-		//	compatible = "amlogic, ppmgr_memory";
-		//	size = <0x0 0x2000000>;
-		//};
+		ppmgr_reserved:linux,ppmgr {
+			compatible = "amlogic, ppmgr_memory";
+			//size = <0x0 0x2000000>;
+		};
 
 		codec_mm_cma:linux,codec_mm_cma {
 			compatible = "shared-dma-pool";
 			reusable;
-			size = <0x0 0xc000000>;
-			alignment = <0x0 0x400000>;
+			size = <0x0 0xa000000>;
+			alignment = <0x0 0x800000>;
 			linux,contiguous-region;
 		};
 		picdec_cma_reserved:linux,picdec {
@@ -122,8 +122,8 @@
 		/* codec shared reserved */
 		codec_mm_reserved:linux,codec_mm_reserved {
 			compatible = "amlogic, codec-mm-reserved";
-			size = <0x0 0x4100000>;
-			alignment = <0x0 0x100000>;
+			size = <0x0 0x6000000>;
+			alignment = <0x0 0x800000>;
  			//no-map;
 		};
 	};
@@ -274,7 +274,7 @@
 	};
 	ppmgr {
 		compatible = "amlogic, ppmgr";//to match of_device_id's compatible member
-		memory-region = <&ion_reserved>;
+		memory-region = <&ppmgr_reserved>;
 		dev_name = "ppmgr";
 		status = "okay";
 	};

--- a/arch/arm64/boot/dts/amlogic/gxbb_p200_2G_wetek_play_2.dts
+++ b/arch/arm64/boot/dts/amlogic/gxbb_p200_2G_wetek_play_2.dts
@@ -52,8 +52,8 @@
 		};
 		pstore:aml_pstore {
 			compatible = "amlogic, pstore";
-			reg = <0x0 0x07300000 0x0 0x100000>;
-			no-map;
+			//reg = <0x0 0x07300000 0x0 0x100000>;
+			//no-map;
 		};
 		fb_reserved:linux,meson-fb {
 			compatible = "amlogic, fb-memory";
@@ -70,7 +70,7 @@
 
 		ion_reserved:linux,ion-dev {
 			compatible = "amlogic, idev-mem";
-			size = <0x0 0x2000000>;
+			//size = <0x0 0x2000000>;
 			multi-use;
 		};
 
@@ -87,16 +87,16 @@
 //			size = <0x0 0x01000000>;
 //		};
 		/*  POST PROCESS MANAGER */
-		//ppmgr_reserved:linux,ppmgr {
-		//	compatible = "amlogic, ppmgr_memory";
-		//	size = <0x0 0x2000000>;
-		//};
+		ppmgr_reserved:linux,ppmgr {
+			compatible = "amlogic, ppmgr_memory";
+			//size = <0x0 0x2000000>;
+		};
 
 		codec_mm_cma:linux,codec_mm_cma {
 			compatible = "shared-dma-pool";
 			reusable;
-			size = <0x0 0xc000000>;
-			alignment = <0x0 0x400000>;
+			size = <0x0 0xa000000>;
+			alignment = <0x0 0x800000>;
 			linux,contiguous-region;
 		};
 		picdec_cma_reserved:linux,picdec {
@@ -122,8 +122,8 @@
 		/* codec shared reserved */
 		codec_mm_reserved:linux,codec_mm_reserved {
 			compatible = "amlogic, codec-mm-reserved";
-			size = <0x0 0x4100000>;
-			alignment = <0x0 0x100000>;
+			size = <0x0 0x6000000>;
+			alignment = <0x0 0x800000>;
  			//no-map;
 		};
 	};
@@ -257,7 +257,7 @@
 	};
 	ppmgr {
 		compatible = "amlogic, ppmgr";//to match of_device_id's compatible member
-		memory-region = <&ion_reserved>;
+		memory-region = <&ppmgr_reserved>;
 		dev_name = "ppmgr";
 		status = "okay";
 	};

--- a/arch/arm64/boot/dts/meson64_odroidc2.dts
+++ b/arch/arm64/boot/dts/meson64_odroidc2.dts
@@ -61,8 +61,8 @@
 		};
 		pstore:aml_pstore {
 			compatible = "amlogic, pstore";
-			reg = <0x0 0x07300000 0x0 0x100000>;
-			no-map;
+			//reg = <0x0 0x07300000 0x0 0x100000>;
+			//no-map;
 		};
 		fb_reserved:linux,meson-fb {
 			compatible = "amlogic, fb-memory";
@@ -79,22 +79,21 @@
 
 		ion_reserved:linux,ion-dev {
 			compatible = "amlogic, idev-mem";
-			size = <0x0 0x2000000>;
+			//size = <0x0 0x2000000>;
 			multi-use;
 		};
 
 		/*  POST PROCESS MANAGER */
 		ppmgr_reserved:linux,ppmgr {
 			compatible = "amlogic, ppmgr_memory";
-			size = <0x0 0x0>;
-			multi-use;
+			//size = <0x0 0x2000000>;
 		};
 
 		codec_mm_cma:linux,codec_mm_cma {
 			compatible = "shared-dma-pool";
 			reusable;
-			size = <0x0 0xc000000>;
-			alignment = <0x0 0x400000>;
+			size = <0x0 0xa000000>;
+			alignment = <0x0 0x800000>;
 			linux,contiguous-region;
 		};
 		picdec_cma_reserved:linux,picdec {
@@ -108,8 +107,8 @@
 		/* codec shared reserved */
 		codec_mm_reserved:linux,codec_mm_reserved {
 			compatible = "amlogic, codec-mm-reserved";
-			size = <0x0 0x4100000>;
-			alignment = <0x0 0x100000>;
+			size = <0x0 0x6000000>;
+			alignment = <0x0 0x800000>;
  			//no-map;
 		};
 	};


### PR DESCRIPTION
This PR moves codec_mm memory from cma to reserved to fit 1080 video needs inside reserved memory

Before: 192 MiB cma and 65 MiB reserved
After: 160 MiB cma and 96 MiB reserved

It also cleans up some unused memory reserves and changes to use 8 MiB alignement for codec_mm (code requirement).

My testing has shown that codec_mm needs the following amount of memory:
- H264: 69 MiB (720/1080p) / 207 MiB (2160p)
- H265: 77 MiB (720p) / 94 MiB (1080p) / 236 MiB (1700p) / 240 MiB (2160p)
- MPEG2/VC-1: 47 MiB

Check `/sys/class/codec_mm/codec_mm_dump` to see how much memory is used when playing a video

This could need some more testing before merging