### PR TITLE
odroid-C2: add PWM support

### DIFF
--- a/arch/arm64/boot/dts/meson64_odroidc2.dts
+++ b/arch/arm64/boot/dts/meson64_odroidc2.dts
@@ -193,20 +193,18 @@
         };
 
 	pwm {
-		compatible = "amlogic, gx-pwm";
+		compatible = "amlogic, odroid-pwm";
+		dev_name = "meson_pwm";
 		status = "okay";
-		pwm-outputs = <0>,<1>,<2>,<3>,<4>,<5>,<6>,<7>;
-		reg = <0x0 0xc1108550 0x0 0x30>,
-				<0x0 0xc8100550 0x0 0x10>;
-		clocks = <&clock CLK_XTAL>,
-				<&clock CLK_VID_PLL>,
-				<&clock CLK_FPLL_DIV4>,
-				<&clock CLK_FPLL_DIV3>;
-		clock-names = "xtal",
-				"vid_pll_clk",
-				"fclk_div4",
-				"fclk_div3";
-		clock-select = <0x0>,<0x0>,<0x0>,<0x0>,<0x3>,<0x0>,<0x0>,<0x0>;
+		pinctrl-names = "odroid_pwm0","odroid_pwm1";
+		pinctrl-0 = <&odroid_pwm0>;
+		pinctrl-1 = <&odroid_pwm1>;
+	};
+
+	pwm-ctrl {
+		compatible = "amlogic, pwm-ctrl";
+		dev_name = "pwm-ctrl";
+		status = "okay";
 	};
 
 	mesonstream {
@@ -873,6 +871,19 @@
                 amlogic,clrmask = <AO 0x80000018>;
                 amlogic,pins = "GPIOAO_13";
         };
+
+	odroid_pwm0: odroid_pwm0 {
+		amlogic,setmask=<3 0x00020000>;
+		amlogic,clrmask=<3 0x00000200>;
+		amlogic,pins="GPIOX_6";
+	};
+	odroid_pwm1: odroid_pwm1 {
+		amlogic,setmask=<3 0x00020000
+		                 3 0x00060000>;
+		amlogic,clrmask=<3 0x00000300
+		                 8 0x00000800>;
+		amlogic,pins="GPIOX_6","GPIOX_7";
+	};
 };
 
 &efuse {

--- a/drivers/amlogic/Makefile
+++ b/drivers/amlogic/Makefile
@@ -133,3 +133,5 @@ obj-$(CONFIG_AML_AO_CEC) += cec/
 obj-$(CONFIG_CRYPTO_AML)	+= crypto/
 
 obj-$(CONFIG_AMLOGIC_WATCHPOINT) += watchpoint/
+
+obj-$(CONFIG_MESON_PWM) += pwm/

--- a/drivers/amlogic/pwm/Kconfig
+++ b/drivers/amlogic/pwm/Kconfig
@@ -18,3 +18,25 @@ config GX_PWM
 	help
 	  say y to enable Amlogic PWM driver.
 endif
+
+config MESON_PWM
+
+    tristate "Amlogic PWM support"
+    default n
+    select PWM
+    help
+      Say yes here to build support for Generic PWM framework
+      driver for AMLOGIC.
+
+      To compile this driver as a module, choose M here: the
+      module will be called pwm-meson.
+
+config MESON_PWM_CTRL
+    tristate "Amlogic PWM Control driver"
+    depends on MESON_PWM
+    help
+      Say yes here to build support for PWM control to
+      Hardkernel devices.
+
+      To compile this driver as a module, choose M here: the
+      module will be called pwm-ctrl.

--- a/drivers/amlogic/pwm/Makefile
+++ b/drivers/amlogic/pwm/Makefile
@@ -3,3 +3,5 @@
 #
 
 obj-$(CONFIG_GX_PWM)		+= pwm-gx.o
+obj-$(CONFIG_MESON_PWM) 	+= pwm-meson.o
+obj-$(CONFIG_MESON_PWM_CTRL) 	+= pwm-ctrl.o

--- a/drivers/amlogic/pwm/pwm-ctrl.c
+++ b/drivers/amlogic/pwm/pwm-ctrl.c
@@ -1,0 +1,460 @@
+/*----------------------------------------------------------------------------
+**
+**  ODROID Board : PWM ctrl driver
+**
+----------------------------------------------------------------------------*/
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/slab.h>
+#include <linux/platform_device.h>
+#include <linux/delay.h>
+#include <linux/sysfs.h>
+#include <linux/input.h>
+#include <linux/gpio.h>
+#include <linux/pwm.h>
+
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/of_gpio.h>
+
+struct pwm_ctrl {
+	struct pwm_device *pwm0;
+	struct pwm_device *pwm1;
+	struct mutex mutex;
+	int pwm0_status, pwm1_status;
+	int freq0, freq1;
+	int duty0, duty1;
+};
+
+#define FREQ_MIN 10         /* 10Hz */
+#define FREQ_MAX 1000000    /* 1MHz */
+#define DUTY_MAX 1024       /* Duty cycle Max */
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static ssize_t set_enable0(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf,
+			size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+	dev_info(dev, "PWM_0 : %s [%d]\n", __func__, val);
+
+	mutex_lock(&ctrl->mutex);
+	if (val) {
+		pwm_disable(ctrl->pwm0);
+		pwm_config(ctrl->pwm0, ctrl->duty0, ctrl->freq0);
+		pwm_enable(ctrl->pwm0);
+		ctrl->pwm0_status = 1;
+	} else {
+		ctrl->pwm0_status = 0;
+		pwm_disable(ctrl->pwm0);
+		pwm_config(ctrl->pwm0, 0, ctrl->freq0);
+	}
+	mutex_unlock(&ctrl->mutex);
+	return count;
+}
+
+static ssize_t show_status0(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	if (ctrl->pwm0_status)
+		return	sprintf(buf, "PWM_0 : %s\n", "on");
+	else
+		return	sprintf(buf, "PWM_0 : %s\n", "off");
+}
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static ssize_t set_duty0(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf,
+			size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+
+	if ((val > DUTY_MAX) || (val < 0)) {
+		dev_err(dev, "PWM_0 : Invalid param. Duty cycle range is 0 to 100\n");
+		return count;
+	}
+	dev_info(dev, "PWM_0 : %s [%d]\n", __func__, val);
+	ctrl->duty0 = val;
+
+	mutex_lock(&ctrl->mutex);
+	if (ctrl->pwm0_status) {
+		pwm_disable(ctrl->pwm0);
+		pwm_config(ctrl->pwm0, ctrl->duty0, ctrl->freq0);
+		pwm_enable(ctrl->pwm0);
+	} else {
+		pwm_config(ctrl->pwm0, 0, ctrl->freq0);
+		pwm_disable(ctrl->pwm0);
+	}
+	mutex_unlock(&ctrl->mutex);
+
+	return count;
+}
+
+static ssize_t show_duty0(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	return	sprintf(buf, "%d\n", ctrl->duty0);
+}
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static ssize_t set_freq0(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf,
+			size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+
+	if ((val < FREQ_MIN) || (val > FREQ_MAX)) {
+		dev_err(dev, "PWM_0 : Invalid param. Frequency range is 10Hz to 1MHz\n");
+		return count;
+	}
+	dev_info(dev, "PWM_0 : %s [%d]\n", __func__, val);
+	ctrl->freq0 = val;
+
+	mutex_lock(&ctrl->mutex);
+	if (ctrl->pwm0_status) {
+		pwm_disable(ctrl->pwm0);
+		pwm_config(ctrl->pwm0, ctrl->duty0, ctrl->freq0);
+		pwm_enable(ctrl->pwm0);
+	} else {
+		pwm_config(ctrl->pwm0, 0, ctrl->freq0);
+		pwm_disable(ctrl->pwm0);
+	}
+	mutex_unlock(&ctrl->mutex);
+
+	return count;
+}
+
+static ssize_t show_freq0(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	return	sprintf(buf, "%d\n", ctrl->freq0);
+}
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static	DEVICE_ATTR(enable0, S_IRWXUGO, show_status0, set_enable0);
+static	DEVICE_ATTR(freq0, S_IRWXUGO, show_freq0, set_freq0);
+static	DEVICE_ATTR(duty0, S_IRWXUGO, show_duty0, set_duty0);
+
+static struct attribute *pwm0_ctrl_sysfs_entries[] = {
+	&dev_attr_enable0.attr,
+	&dev_attr_freq0.attr,
+	&dev_attr_duty0.attr,
+	NULL
+};
+
+static struct attribute_group pwm0_ctrl_attr_group = {
+	.name   = NULL,
+	.attrs  = pwm0_ctrl_sysfs_entries,
+};
+
+/*----------------------------------------------------------------------------*/
+static ssize_t set_enable1(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf,
+			size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+
+	dev_info(dev, "PWM_1 : %s [%d]\n", __func__, val);
+	mutex_lock(&ctrl->mutex);
+	if (val) {
+		ctrl->pwm1_status = 1;
+		pwm_config(ctrl->pwm1, ctrl->duty1, ctrl->freq1);
+		pwm_enable(ctrl->pwm1);
+	} else {
+		pwm_config(ctrl->pwm1, 0, ctrl->freq1);
+		pwm_disable(ctrl->pwm1);
+		ctrl->pwm1_status = 0;
+	}
+	mutex_unlock(&ctrl->mutex);
+
+	return count;
+}
+
+static	ssize_t show_status1(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	if (ctrl->pwm1_status)
+		return	sprintf(buf, "PWM_1 : %s\n", "on");
+	else
+		return	sprintf(buf, "PWM_1 : %s\n", "off");
+}
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static	ssize_t set_duty1(
+		struct device *dev,
+		struct device_attribute *attr,
+		const char *buf,
+		size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+
+	if ((val > DUTY_MAX) || (val < 0)) {
+		dev_err(dev, "PWM_1 : Invalid param. Duty cycle range is 0 to 100\n");
+		return count;
+	}
+	dev_info(dev, "PWM_1 : %s [%d]\n", __func__, val);
+	ctrl->duty1 = val;
+
+	mutex_lock(&ctrl->mutex);
+	if (ctrl->pwm1_status) {
+		pwm_disable(ctrl->pwm1);
+		pwm_config(ctrl->pwm1, ctrl->duty1, ctrl->freq1);
+		pwm_enable(ctrl->pwm1);
+	} else {
+		pwm_config(ctrl->pwm1, 0, ctrl->freq1);
+		pwm_disable(ctrl->pwm1);
+	}
+	mutex_unlock(&ctrl->mutex);
+
+	return count;
+}
+
+static ssize_t show_duty1(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	return	sprintf(buf, "%d\n", ctrl->duty1);
+}
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+static ssize_t set_freq1(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf,
+			size_t count)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	unsigned int val;
+	int ret = 0;
+
+	ret = sscanf(buf, "%u\n", &val);
+	if (!ret)
+		return -EINVAL;
+
+	if ((val < FREQ_MIN) || (val > FREQ_MAX)) {
+		dev_err(dev, "PWM_1 : Invalid param. Frequency range is 10Hz to 1MHz\n");
+		return count;
+	}
+	dev_info(dev, "PWM_1 : %s [%d]\n", __func__, val);
+	ctrl->freq1 = val;
+
+	mutex_lock(&ctrl->mutex);
+	if (ctrl->pwm1_status) {
+		pwm_disable(ctrl->pwm1);
+		pwm_config(ctrl->pwm1, ctrl->duty1, ctrl->freq1);
+		pwm_enable(ctrl->pwm1);
+	} else {
+		pwm_config(ctrl->pwm1, 0, ctrl->freq1);
+		pwm_disable(ctrl->pwm1);
+	}
+	mutex_unlock(&ctrl->mutex);
+	return count;
+}
+
+static ssize_t show_freq1(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+{
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+	return	sprintf(buf, "%d\n", ctrl->freq1);
+}
+
+/*----------------------------------------------------------------------------*/
+static	DEVICE_ATTR(enable1, S_IRWXUGO, show_status1, set_enable1);
+static	DEVICE_ATTR(freq1, S_IRWXUGO, show_freq1, set_freq1);
+static	DEVICE_ATTR(duty1, S_IRWXUGO, show_duty1, set_duty1);
+static struct attribute *pwm1_ctrl_sysfs_entries[] = {
+	&dev_attr_enable1.attr,
+	&dev_attr_freq1.attr,
+	&dev_attr_duty1.attr,
+	NULL
+};
+static struct attribute_group pwm1_ctrl_attr_group = {
+	.name   = NULL,
+	.attrs  = pwm1_ctrl_sysfs_entries,
+};
+
+/*----------------------------------------------------------------------------*/
+static int pwm_ctrl_resume(struct platform_device *dev)
+{
+#if defined(DEBUG_PM_MSG)
+	dev_info(dev, "%s\n", __func__);
+#endif
+	return  0;
+}
+
+/*----------------------------------------------------------------------------*/
+static int pwm_ctrl_suspend(struct platform_device *dev, pm_message_t state)
+{
+	return 0;
+}
+
+/*----------------------------------------------------------------------------*/
+static int pwm_ctrl_probe(struct platform_device *pdev)
+{
+	struct pwm_ctrl *ctrl;
+	struct device *dev = &pdev->dev;
+	int ret = 0;
+
+	ctrl = devm_kzalloc(&pdev->dev, sizeof(*ctrl), GFP_KERNEL);
+	if (!ctrl) {
+		dev_err(&pdev->dev, "no memory for state\n");
+		ret = -ENOMEM;
+		goto err_alloc;
+	}
+
+	ctrl->pwm0 = pwm_request(0, "pwm-ctrl");
+	if (IS_ERR(ctrl->pwm0)) {
+		dev_err(&pdev->dev, "unable to request legacy PWM\n");
+		ret = PTR_ERR(ctrl->pwm0);
+		goto err_request;
+	}
+
+	ctrl->pwm1 = pwm_request(1, "pwm-ctrl");
+	if (IS_ERR(ctrl->pwm1)) {
+		dev_err(&pdev->dev, "cannot export to PWM-1 : modprobe pwm-meson npwm=2\n");
+		ctrl->pwm1 = NULL;
+	}
+
+	mutex_init(&ctrl->mutex);
+	dev_set_drvdata(dev, ctrl);
+
+	ret = sysfs_create_group(&dev->kobj, &pwm0_ctrl_attr_group);
+	if (ret < 0)
+		dev_err(&pdev->dev, "failed to create sysfs group !!\n");
+
+	if (ctrl->pwm1 != NULL) {
+		ret = sysfs_create_group(&dev->kobj, &pwm1_ctrl_attr_group);
+		if (ret < 0)
+			dev_err(&pdev->dev, "failed to create sysfs group !!\n");
+	}
+
+	return 0;
+
+err_request:
+	devm_kfree(&pdev->dev, ctrl);
+	kfree(ctrl);
+err_alloc:
+	return ret;
+}
+
+/*----------------------------------------------------------------------------*/
+static int pwm_ctrl_remove(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct pwm_ctrl *ctrl = dev_get_drvdata(dev);
+
+	if (ctrl->pwm1 != NULL)
+		sysfs_remove_group(&dev->kobj, &pwm1_ctrl_attr_group);
+	sysfs_remove_group(&dev->kobj, &pwm0_ctrl_attr_group);
+
+	if (ctrl->pwm1)
+		pwm_free(ctrl->pwm1);
+
+	if (ctrl->pwm0)
+		pwm_free(ctrl->pwm0);
+
+	devm_kfree(dev, ctrl);
+	return 0;
+}
+
+/*----------------------------------------------------------------------------*/
+#if defined(CONFIG_OF)
+static const struct of_device_id pwm_ctrl_dt[] = {
+	{ .compatible = "amlogic, pwm-ctrl" },
+	{ },
+};
+#endif
+
+/*----------------------------------------------------------------------------*/
+static struct platform_driver pwm_ctrl_driver = {
+	.driver = {
+		.name = "pwm-ctrl",
+		.owner = THIS_MODULE,
+#if defined(CONFIG_OF)
+		.of_match_table = of_match_ptr(pwm_ctrl_dt),
+#endif
+	},
+	.probe = pwm_ctrl_probe,
+	.remove = pwm_ctrl_remove,
+	.suspend = pwm_ctrl_suspend,
+	.resume = pwm_ctrl_resume,
+};
+
+/*----------------------------------------------------------------------------*/
+static int __init pwm_ctrl_init(void)
+{
+	return platform_driver_register(&pwm_ctrl_driver);
+}
+
+/*----------------------------------------------------------------------------*/
+static void __exit pwm_ctrl_exit(void)
+{
+	platform_driver_unregister(&pwm_ctrl_driver);
+}
+
+/*----------------------------------------------------------------------------*/
+module_init(pwm_ctrl_init);
+module_exit(pwm_ctrl_exit);
+
+MODULE_DESCRIPTION("PWM ctrl driver for odroid-Dev board");
+MODULE_AUTHOR("HardKernel");
+MODULE_LICENSE("GPL");
+
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/

--- a/drivers/amlogic/pwm/pwm-meson.c
+++ b/drivers/amlogic/pwm/pwm-meson.c
@@ -1,0 +1,358 @@
+/*
+ * pwm-meson.c
+ *
+ * Support for Meson current source PWM
+ *
+ * Copyright (C) 2012 Elvis Yu <elvis.yu@amlogic.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any kind,
+ * whether express or implied; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/err.h>
+#include <linux/platform_device.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/delay.h>
+#include <linux/slab.h>
+#include <linux/io.h>
+#include <linux/of.h>
+#include <linux/pwm.h>
+
+#include <linux/amlogic/iomap.h>
+#include <linux/pinctrl/consumer.h>
+#include <linux/amlogic/aml_dvfs.h>
+#include <linux/amlogic/cpu_version.h>
+
+#define PWM_PWM_A		0x2154
+#define PWM_PWM_B		0x2155
+#define PWM_MISC_REG_AB		0x2156
+#define PWM_PWM_C		0x2194
+#define PWM_PWM_D		0x2195
+#define PWM_MISC_REG_CD		0x2196
+#define PWM_PWM_E		0x21b0
+#define PWM_PWM_F		0x21b1
+#define PWM_MISC_REG_EF		0x21b2
+#define LED_PWM_REG0		0x21da
+
+static int npwm = 1;
+module_param(npwm, int, 0644);
+MODULE_PARM_DESC(npwm , "\n odroid-c1 The number of available pwm (max 2-port)\n");
+
+#define PWM_A   0
+#define PWM_F   1
+#define FIN_FREQ		(24 * 1000)
+#define DUTY_MAX 1024
+
+struct meson_pwm_device {
+	unsigned int		freq;
+	unsigned int		duty;
+	unsigned char		pwm_id;
+	struct pwm_device	*pwm;
+};
+
+struct meson_chip {
+	struct platform_device	*pdev;
+	struct pwm_chip		    chip;
+	struct meson_pwm_device *meson_pwm[2];
+	struct pinctrl *pinctrl;
+};
+
+#define to_meson_chip(chip)	container_of(chip, struct meson_chip, chip)
+#define pwm_dbg(_pwm, msg...) dev_dbg(&(_pwm)->pdev->dev, msg)
+
+static void meson_pwm_init(struct device *dev, int pwmn)
+{
+	if (pwmn == 1)
+		aml_write_cbus(PWM_MISC_REG_AB,
+			(aml_read_cbus(PWM_MISC_REG_AB) &
+			~(0x7f << 8)) | ((1 << 15)));
+	else {
+		aml_write_cbus(PWM_MISC_REG_AB,
+			(aml_read_cbus(PWM_MISC_REG_AB) &
+			~(0x7f << 8)) | ((1 << 15)));
+		aml_write_cbus(PWM_MISC_REG_EF,
+			(aml_read_cbus(PWM_MISC_REG_EF) &
+			~(0x7f << 16)) | ((1 << 23)));
+	}
+	return;
+}
+
+static int meson_pwm_enable(struct pwm_chip *chip, struct pwm_device *pwm)
+{
+	struct meson_chip *meson = to_meson_chip(chip);
+	struct meson_pwm_device *meson_pwm;
+	unsigned int id = pwm->pwm;
+
+	meson_pwm = meson->meson_pwm[id];
+	switch (id) {
+	case PWM_A:
+		/*enable pwm_a*/
+		aml_cbus_update_bits(PWM_MISC_REG_AB, 3<<0, 1);
+		break;
+	case PWM_F:
+		/*enable pwm_f*/
+		aml_cbus_update_bits(PWM_MISC_REG_EF, 3<<0, 2);
+		break;
+	}
+
+	return 0;
+}
+
+static void meson_pwm_disable(struct pwm_chip *chip, struct pwm_device *pwm)
+{
+	struct meson_chip *meson = to_meson_chip(chip);
+	struct meson_pwm_device *meson_pwm;
+	unsigned int id = pwm->pwm;
+
+	meson_pwm = meson->meson_pwm[id];
+	switch (id) {
+	case PWM_A:
+		/* disable pwm_a */
+		aml_cbus_update_bits(PWM_MISC_REG_AB, 3 << 0, 0);
+		break;
+	case PWM_F:
+		/* disable pwm_f */
+		aml_cbus_update_bits(PWM_MISC_REG_EF, 3 << 0, 0);
+		break;
+	}
+	return;
+}
+
+static int meson_pwm_config(struct pwm_chip *chip, struct pwm_device *pwm,
+		int duty, int pwm_freq)
+{
+	struct meson_chip *meson = to_meson_chip(chip);
+	struct meson_pwm_device *meson_pwm;
+	unsigned int id = pwm->pwm;
+	struct device *dev = chip->dev;
+	unsigned pwm_hi = 0, pwm_lo = 0;
+	unsigned fout_freq = 0, pwm_cnt, pwm_pre_div;
+	unsigned long temp = 0;
+	int i = 0;
+
+	if ((duty < 0) || (duty > DUTY_MAX)) {
+		dev_err(dev, "Not available duty... error!!!\n");
+		return -EINVAL;
+	}
+	meson_pwm = meson->meson_pwm[id];
+
+	fout_freq =
+		((pwm_freq >= (FIN_FREQ * 500)) ? (FIN_FREQ * 500) : pwm_freq);
+	for (i = 0; i < 0x7f; i++) {
+		pwm_pre_div = i;
+		pwm_cnt = FIN_FREQ * 1000 / (pwm_freq * (pwm_pre_div + 1)) - 2;
+		if (pwm_cnt <= 0xffff)
+			break;
+	}
+
+	if (duty == 0) {
+		pwm_hi = 0;
+		pwm_lo = pwm_cnt;
+		goto div_set;
+	} else if (duty == DUTY_MAX) {
+		pwm_hi = pwm_cnt;
+		pwm_lo = 0;
+		goto div_set;
+	}
+
+	temp = pwm_cnt*duty;
+	temp /= DUTY_MAX;
+	pwm_hi = (unsigned)temp;
+	pwm_lo = pwm_cnt - pwm_hi;
+
+div_set:
+	switch (id) {
+	case PWM_A:
+		/*pwm_a_clk_div*/
+		aml_cbus_update_bits(
+			PWM_MISC_REG_AB, 7<<8, pwm_pre_div<<8);
+		aml_write_cbus(PWM_PWM_A, (pwm_hi << 16) | (pwm_lo));
+		break;
+	case PWM_F:
+		/*pwm_f_clk_div*/
+		aml_cbus_update_bits(
+			PWM_MISC_REG_EF, 7<<16, pwm_pre_div<<16);
+		aml_write_cbus(PWM_PWM_F, (pwm_hi << 16) | (pwm_lo));
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int meson_pwm_request(struct pwm_chip *chip,
+				 struct pwm_device *pwm)
+{
+	struct meson_chip *meson = to_meson_chip(chip);
+	unsigned int id = pwm->pwm;
+
+	meson->meson_pwm[id] = devm_kzalloc(chip->dev,
+				sizeof(struct meson_pwm_device), GFP_KERNEL);
+	if (!meson->meson_pwm[id])
+		return -ENOMEM;
+
+	meson->meson_pwm[id]->pwm_id = id;
+
+	meson->meson_pwm[id]->pwm = pwm;
+	pwm_set_chip_data(pwm, meson->meson_pwm[id]);
+
+	return 0;
+}
+
+static void meson_pwm_free(struct pwm_chip *chip,
+				struct pwm_device *pwm)
+{
+	struct meson_chip *meson = to_meson_chip(chip);
+	unsigned int id = pwm->pwm;
+
+	if (meson->pinctrl) {
+		devm_pinctrl_put(meson->pinctrl);
+		meson->pinctrl = NULL;
+	}
+
+	devm_kfree(chip->dev, meson->meson_pwm[id]);
+}
+
+static struct pwm_ops meson_pwm_ops = {
+	.request = meson_pwm_request,
+	.free = meson_pwm_free,
+	.enable = meson_pwm_enable,
+	.disable = meson_pwm_disable,
+	.config = meson_pwm_config,
+	.owner = THIS_MODULE,
+};
+
+static int meson_pwm_probe(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	struct device *dev = &pdev->dev;
+	struct meson_chip *meson;
+	char prop_name[20];
+	int ret = 0;
+
+	if (!np)
+		return -ENODEV;
+
+	if ((npwm <= 0) || (npwm > 2)) {
+		dev_err(dev, "Available pwm_device number error.\n");
+		return -EINVAL;
+	}
+
+	meson = devm_kzalloc(&pdev->dev, sizeof(*meson), GFP_KERNEL);
+	if (meson == NULL) {
+		dev_err(dev, "failed to allocate pwm_device\n");
+		return -ENOMEM;
+	}
+
+	meson->pdev = pdev;
+	meson->chip.dev = &pdev->dev;
+	meson->chip.ops = &meson_pwm_ops;
+	meson->chip.base = -1;
+	meson->chip.npwm = npwm;
+
+	ret = pwmchip_add(&meson->chip);
+	if (ret < 0) {
+		dev_err(dev, "failed to register pwm\n");
+		return ret;
+	}
+	platform_set_drvdata(pdev, meson);
+
+	if (npwm == 2)
+		strcpy(prop_name, "odroid_pwm1");
+	else
+		strcpy(prop_name, "odroid_pwm0");
+
+	meson->pinctrl = devm_pinctrl_get_select(&pdev->dev, prop_name);
+	if (IS_ERR(meson->pinctrl)) {
+		dev_err(&pdev->dev, "pinmux error\n");
+		return -ENODEV;
+	}
+	dev_info(&pdev->dev, "pinctrl_name = %s\n", prop_name);
+
+	meson_pwm_init(dev, npwm);
+
+	dev_info(dev, "register pwm device.. %s\n", __func__);
+	return 0;
+}
+
+static int meson_pwm_remove(struct platform_device *pdev)
+{
+	struct meson_chip *meson = platform_get_drvdata(pdev);
+	int err;
+
+
+	err = pwmchip_remove(&meson->chip);
+	if (err < 0)
+		return err;
+
+	devm_kfree(meson->chip.dev, meson);
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_SLEEP
+static int meson_pwm_suspend(struct device *dev)
+{
+	return 0;
+}
+
+static int meson_pwm_resume(struct device *dev)
+{
+	return 0;
+}
+#endif
+
+static SIMPLE_DEV_PM_OPS(meson_pwm_pm_ops, meson_pwm_suspend,
+			meson_pwm_resume);
+
+#ifdef CONFIG_OF
+static const struct of_device_id meson_pwm_of_match[] = {
+	{.compatible = "amlogic, odroid-pwm",},
+	{},
+};
+#else
+#define meson_pwm_of_match NULL
+#endif
+
+static struct platform_driver meson_pwm_driver = {
+	.driver		= {
+		.name	= "meson_pwm",
+		.owner	= THIS_MODULE,
+		.of_match_table = meson_pwm_of_match,
+		.pm	= &meson_pwm_pm_ops,
+	},
+	.probe		= meson_pwm_probe,
+	.remove		= meson_pwm_remove,
+};
+
+static int __init module_pwm_init(void)
+{
+	int ret;
+
+	ret = platform_driver_register(&meson_pwm_driver);
+	if (ret)
+		pr_err("failed to add pwm driver\n");
+
+	return ret;
+}
+
+static void __exit module_pwm_exit(void)
+{
+	platform_driver_unregister(&meson_pwm_driver);
+}
+module_init(module_pwm_init);
+module_exit(module_pwm_exit);
+
+MODULE_DESCRIPTION("AMLogic meson8b PWM driver");
+MODULE_AUTHOR("HardKernel");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Add PWM control from HardKernel Repo and rebase .dts

Confirmed working here with this current linux-amlogic Kernel:
http://forum.odroid.com/viewtopic.php?f=144&t=24923&start=150#p175266

PR for aarch64 Kernel config still to come.