### PR TITLE
Fix framerate automation in Amlogic kernel 3.10 when amlvideo is included into VFM map

### DIFF
--- a/drivers/amlogic/video_dev/amlvideo.c
+++ b/drivers/amlogic/video_dev/amlvideo.c
@@ -324,6 +324,13 @@ static int video_receiver_event_fun(int type, void* data, void* private_data) {
             vfq_init(&q_omx, AMLVIDEO_POOL_SIZE+1, &amlvideo_pool_omx[0]);
         }
     }
+    else if (type == VFRAME_EVENT_PROVIDER_FR_HINT) {
+        vf_notify_receiver(PROVIDER_NAME,VFRAME_EVENT_PROVIDER_FR_HINT,data);
+    }
+    else if (type == VFRAME_EVENT_PROVIDER_FR_END_HINT) {
+        vf_notify_receiver(PROVIDER_NAME,VFRAME_EVENT_PROVIDER_FR_END_HINT,data);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
This PR makes framerate automation in Amlogic kernel 3.10 to function properly with Kodi 17 Krypton.