### PR TITLE
amports: optimise hevc & vp9 playback

### DIFF
--- a/drivers/amlogic/amports/vh265.c
+++ b/drivers/amlogic/amports/vh265.c
@@ -215,7 +215,7 @@ static u32 dynamic_buf_num_margin;
 #else
 static u32 buf_alloc_width;
 static u32 buf_alloc_height;
-static u32 dynamic_buf_num_margin = 7;
+static u32 dynamic_buf_num_margin = 16;
 #endif
 static u32 buf_alloc_size;
 static u32 re_config_pic_flag;

--- a/drivers/amlogic/amports/vvp9.c
+++ b/drivers/amlogic/amports/vvp9.c
@@ -1693,7 +1693,7 @@ static u32 dynamic_buf_num_margin;
 #else
 static u32 buf_alloc_width;
 static u32 buf_alloc_height;
-static u32 dynamic_buf_num_margin = 7;
+static u32 dynamic_buf_num_margin = 16;
 #endif
 static u32 buf_alloc_depth = 10;
 static u32 buf_alloc_size;


### PR DESCRIPTION
There have been a few of us now sitting on this tweak for HEVC and VP9 video playback for a while now. 
So we should get it incorporated for LE 8.0.1 release.

This helps/fixes problematic playback of 1080p HEVC as seen here:
http://forum.odroid.com/viewtopic.php?f=144&t=24753&start=600#p180279

Heads up to @Raybuntu & @kszaq 