### PR TITLE
Mali-450 GXBB: Revert turbo mode and enable 792MHz

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
@@ -26,10 +26,8 @@
 		pmu_domain_config = <0x1 0x2 0x4 0x4 0x0 0x0 0x0 0x0 0x0 0x1 0x2 0x0>;
 		pmu_switch_delay = <0xffff> ;
 		num_of_pp = <3> ;
-		def_clk = <4>;
-		min_clk = <4>;
+		def_clk = <3>;
 		sc_mpp = <3>;/* number of pp used most of time.*/
-		min_pp = <3>;
 		tbl = <&clk125_cfg &clk285_cfg &clk400_cfg &clk500_cfg &clk666_cfg &clk800_cfg>;
 
 		clocks = <&clock CLK_FPLL_DIV3>,

--- a/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb-gpu-mali450.dtsi
@@ -28,7 +28,7 @@
 		num_of_pp = <3> ;
 		def_clk = <3>;
 		sc_mpp = <3>;/* number of pp used most of time.*/
-		tbl = <&clk125_cfg &clk285_cfg &clk400_cfg &clk500_cfg &clk666_cfg &clk800_cfg>;
+		tbl = <&clk125_cfg &clk285_cfg &clk400_cfg &clk500_cfg &clk666_cfg &clk800_cfg &clk800_cfg>;
 
 		clocks = <&clock CLK_FPLL_DIV3>,
 			<&clock CLK_FPLL_DIV4>,


### PR DESCRIPTION
The first patch reverts setting Mali to 666MHz as this is not needed after https://github.com/LibreELEC/LibreELEC.tv/pull/1390

The second patch enables setting Mali operating frequency to 792MHz.

Before the patch:
`WHub:~ # cat /sys/class/mpgpu/max_freq`
`4`
`WHub:~ # echo 4 > /sys/class/mpgpu/cur_freq && cat /sys/class/mpgpu/cur_freq`
`666`

After the patch:
`WHub:~ # cat /sys/class/mpgpu/max_freq`
`5`
`WHub:~ # echo 5 > /sys/class/mpgpu/cur_freq && cat /sys/class/mpgpu/cur_freq`
`792`

The 792MHz Mali frequency seems to be stable for me on WHub and Odroid-C2 (both running 1 day at that speed, only Kodi "load" on GPU).