### PR TITLE
Makefile: add -mstrict-align flag to KBUILD_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,8 @@ KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common \
 		   -Wno-format-security \
-		   -fno-delete-null-pointer-checks
+		   -fno-delete-null-pointer-checks \
+		   -mstrict-align
 KBUILD_CFLAGS   += -Wno-error=cpp
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=


### PR DESCRIPTION
Fixes an alignment fault in Amlogic MMC driver when kernel is compiled with GCC 7.1.0.