### PR TITLE
[3.14] Initialize MMC devices in predictable order

### DIFF
--- a/drivers/amlogic/mmc/aml_sd_emmc.c
+++ b/drivers/amlogic/mmc/aml_sd_emmc.c
@@ -3625,7 +3625,6 @@ static int aml_sd_emmc_probe(struct platform_device *pdev)
 	pdata->need_retuning = false;
 	pdata->signal_voltage = 0xff; /* init as an invalid value */
 	host->is_tunning = 0;
-	mmc->index = 0;
 	mmc->ops = &aml_sd_emmc_ops;
 	mmc->alldev_claim = &aml_sd_emmc_claim;
 	mmc->ios.clock = 400000;

--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -87,7 +87,6 @@ static int max_devices;
 
 /* 256 minors, so at most 256 separate devices */
 static DECLARE_BITMAP(dev_use, 256);
-static DECLARE_BITMAP(name_use, 256);
 
 /*
  * There is one mmc_blk_data per slot.
@@ -106,7 +105,6 @@ struct mmc_blk_data {
 	unsigned int	usage;
 	unsigned int	read_only;
 	unsigned int	part_type;
-	unsigned int	name_idx;
 	unsigned int	reset_done;
 #define MMC_BLK_READ		BIT(0)
 #define MMC_BLK_WRITE		BIT(1)
@@ -2094,19 +2092,6 @@ static struct mmc_blk_data *mmc_blk_alloc_req(struct mmc_card *card,
 		goto out;
 	}
 
-	/*
-	 * !subname implies we are creating main mmc_blk_data that will be
-	 * associated with mmc_card with mmc_set_drvdata. Due to device
-	 * partitions, devidx will not coincide with a per-physical card
-	 * index anymore so we keep track of a name index.
-	 */
-	if (!subname) {
-		md->name_idx = find_first_zero_bit(name_use, max_devices);
-		__set_bit(md->name_idx, name_use);
-	} else
-		md->name_idx = ((struct mmc_blk_data *)
-				dev_to_disk(parent)->private_data)->name_idx;
-
 	md->area_type = area_type;
 
 	/*
@@ -2155,7 +2140,7 @@ static struct mmc_blk_data *mmc_blk_alloc_req(struct mmc_card *card,
 	 */
 
 	snprintf(md->disk->disk_name, sizeof(md->disk->disk_name),
-		 "mmcblk%d%s", md->name_idx, subname ? subname : "");
+		 "mmcblk%u%s", card->host->index, subname ? subname : "");
 
 	if (mmc_card_mmc(card))
 		blk_queue_logical_block_size(md->queue.queue,
@@ -2310,7 +2295,6 @@ static void mmc_blk_remove_parts(struct mmc_card *card,
 	struct list_head *pos, *q;
 	struct mmc_blk_data *part_md;
 
-	__clear_bit(md->name_idx, name_use);
 	list_for_each_safe(pos, q, &md->part) {
 		part_md = list_entry(pos, struct mmc_blk_data, part);
 		list_del(pos);


### PR DESCRIPTION
Make sure MMC devices (mmcblkX) always get predictable index (in the order they are defined in device tree).

Because MMC devices are initialized asynchronously to optimize boot time, we cannot guarantee mmcblkX will belong to specific MMC device. Amlogic boards usually have /dev/mmcblk0 representing SD card slot. But in some cases if the device has internal eMMC memory, SD-card slot may become /dev/mmcblk1 while /dev/mmcblk0 is assigned to internal eMMC.

This PR makes sure MMC devices are always get indexes assigned in the order they are defined in device tree.