### PR TITLE
Add support for ODROID C2 IR remote to RC core

### DIFF
--- a/arch/arm64/boot/dts/meson64_odroidc2.dts
+++ b/arch/arm64/boot/dts/meson64_odroidc2.dts
@@ -894,4 +894,5 @@
 };
 &meson_ir {
 	status = "okay";
+	linux,rc-map-name = "rc-odroid";
 };

--- a/drivers/media/rc/keymaps/Makefile
+++ b/drivers/media/rc/keymaps/Makefile
@@ -63,6 +63,7 @@ obj-$(CONFIG_RC_MAP) += rc-adstech-dvb-t-pci.o \
 			rc-nebula.o \
 			rc-nec-terratec-cinergy-xs.o \
 			rc-norwood.o \
+                        rc-odroid.o \
 			rc-npgtech.o \
 			rc-pctv-sedna.o \
 			rc-pinnacle-color.o \

--- a/drivers/media/rc/keymaps/rc-odroid.c
+++ b/drivers/media/rc/keymaps/rc-odroid.c
@@ -1,0 +1,52 @@
+/* Keytable for ODROID IR Remote Controller
+ *
+ * Copyright (c) 2017 Hardkernel co., Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <media/rc-map.h>
+#include <linux/module.h>
+
+static struct rc_map_table odroid[] = {
+	{ 0xb2dc, KEY_POWER },
+	{ 0xb288, KEY_MUTE },
+	{ 0xb282, KEY_HOME },
+	{ 0xb2ce, KEY_OK },
+	{ 0xb2ca, KEY_UP },
+	{ 0xb299, KEY_LEFT },
+	{ 0xb2c1, KEY_RIGHT },
+	{ 0xb2d2, KEY_DOWN },
+	{ 0xb2c5, KEY_MENU },
+	{ 0xb29a, KEY_BACK },
+	{ 0xb281, KEY_VOLUMEDOWN },
+	{ 0xb280, KEY_VOLUMEUP },
+};
+
+static struct rc_map_list odroid_map = {
+	.map = {
+		.scan    = odroid,
+		.size    = ARRAY_SIZE(odroid),
+		.rc_type = RC_TYPE_NEC,
+		.name    = RC_MAP_ODROID,
+	}
+};
+
+static int __init init_rc_map_odroid(void)
+{
+	return rc_map_register(&odroid_map);
+}
+
+static void __exit exit_rc_map_odroid(void)
+{
+	rc_map_unregister(&odroid_map);
+}
+
+module_init(init_rc_map_odroid)
+module_exit(exit_rc_map_odroid)
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Hardkernel co., Ltd.");

--- a/include/media/rc-map.h
+++ b/include/media/rc-map.h
@@ -157,6 +157,7 @@ void rc_map_init(void);
 #define RC_MAP_NEC_TERRATEC_CINERGY_XS   "rc-nec-terratec-cinergy-xs"
 #define RC_MAP_NORWOOD                   "rc-norwood"
 #define RC_MAP_NPGTECH                   "rc-npgtech"
+#define RC_MAP_ODROID                    "rc-odroid"
 #define RC_MAP_PCTV_SEDNA                "rc-pctv-sedna"
 #define RC_MAP_PINNACLE_COLOR            "rc-pinnacle-color"
 #define RC_MAP_PINNACLE_GREY             "rc-pinnacle-grey"


### PR DESCRIPTION
The C2 also uses the NEC protocol for IR.

Tested in conjunction with @codesnake's PR #58 

Thx to @Kwiboo 