### PR TITLE
ODROID C2: Fix usb/dwc_otg

### DIFF
--- a/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd_intr.c
+++ b/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd_intr.c
@@ -1302,7 +1302,7 @@ static int32_t handle_hc_nak_intr(dwc_otg_hcd_t *hcd,
 			hcd->ssplit_lock = 0;
 
 		qtd->complete_split = 0;
-		if (qtd->error_count > 200) {
+		if (qtd->error_count > 20000) {
 			DWC_ERROR("Can not read device info from hub.We take it error\n");
 			halt_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_XACT_ERR);
 		} else {

--- a/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd_queue.c
+++ b/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd_queue.c
@@ -367,13 +367,13 @@ static int check_periodic_bandwidth(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh)
 		 * Max periodic usecs is 80% x 125 usec = 100 usec.
 		 */
 
-		max_claimed_usecs = 100 - qh->usecs;
+		max_claimed_usecs = 125 - qh->usecs;
 	else
 		/*
 		 * Full speed mode.
 		 * Max periodic usecs is 90% x 1000 usec = 900 usec.
 		 */
-		max_claimed_usecs = 900 - qh->usecs;
+		max_claimed_usecs = 1000 - qh->usecs;
 
 	if (hcd->periodic_usecs > max_claimed_usecs) {
 		DWC_INFO("%s: already claimed usecs %d, required usecs %d\n", __func__, hcd->periodic_usecs, qh->usecs);


### PR DESCRIPTION
Problems with C2 USB HID attached devices are shown as errors in the Kernel log:

> [    5.737077@1] Bluetooth: Core ver 2.18
> [    5.737132@1] NET: Registered protocol family 31
> [    5.737136@1] Bluetooth: HCI device and connection manager initialized
> [    5.737162@1] Bluetooth: HCI socket layer initialized
> [    5.737170@1] Bluetooth: L2CAP socket layer initialized
> [    5.737201@1] Bluetooth: SCO socket layer initialized
> [    5.750594@0] usbcore: registered new interface driver btusb
> [    5.888840@0] ERROR::handle_hc_nak_intr:1306: Can not read device info from hub.We take it error
> [    5.888840@0] 
> [    5.953043@2] input: lircd-uinput as /devices/virtual/input/input8
> [    6.091726@0] 8021q: 802.1Q VLAN Support v1.8

Solution was to pull in some Hardkernel commits to fix USB Hub HID issues.

On the C2 this also allows BT USB HID devices like the Xiaomi Mi Box remote (with further LE patching) and the PS3 USB connected controllers to work properly.

The Lakka guys will likely be interested in USB controllers working.

Also required as a Kernel Config:

```
@@ -2720,7 +2719,7 @@
 CONFIG_HID=y
 # CONFIG_HID_BATTERY_STRENGTH is not set
 CONFIG_HIDRAW=y
-# CONFIG_UHID is not set
+CONFIG_UHID=y
 CONFIG_HID_GENERIC=y
```
Tested only on the C2, further testing required on the WeTek Hub / Play2

ping @Raybuntu @kszaq @codesnake 

