### PR TITLE
Allow devices to not have Amlogic-style partition table

### DIFF
--- a/drivers/amlogic/mmc/emmc_partitions.c
+++ b/drivers/amlogic/mmc/emmc_partitions.c
@@ -672,6 +672,9 @@ int aml_emmc_partition_ops(struct mmc_card *card, struct gendisk *disk)
 	if (!is_card_emmc(card)) /* not emmc, nothing to do */
 		return 0;
 
+	if (!of_find_node_by_path("/partitions"))
+		return 0;
+
 	store_device = host->storage_flag;
 	pt_fmt = kmalloc(sizeof(struct mmc_partitions_fmt), GFP_KERNEL);
 	if (pt_fmt == NULL) {

--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -45,9 +45,7 @@
 #include <asm/uaccess.h>
 
 #include "queue.h"
-#if !defined(CONFIG_ARCH_MESON64_ODROIDC2)
 #include <linux/mmc/emmc_partitions.h>
-#endif
 
 MODULE_ALIAS("mmc:block");
 #ifdef MODULE_PARAM_PREFIX
@@ -2488,9 +2486,7 @@ static int mmc_blk_probe(struct mmc_card *card)
 	if (mmc_add_disk(md))
 		goto out;
 
-#if !defined(CONFIG_ARCH_MESON64_ODROIDC2)
 	aml_emmc_partition_ops(card, md->disk); /* add by gch */
-#endif
 
 	list_for_each_entry(part_md, &md->part, part) {
 		if (mmc_add_disk(part_md))


### PR DESCRIPTION
We may want to use standard partition table on devices other than Odroid-C2. These patches change partition layout check so that if Android-style partitions are not defined in device tree (e.g. for Odroid-C2), a standard partition table is used.

Tested with many Android-running devices and Odroid-C2 in my community builds.