### PR TITLE
Add reading ethernet MAC address from eFuse, NAND

### DIFF
--- a/drivers/amlogic/efuse/efuse64.c
+++ b/drivers/amlogic/efuse/efuse64.c
@@ -381,7 +381,7 @@ error_exit:
 	return ret;
 }
 
-char *efuse_get_mac(char *addr)
+int efuse_get_mac(char *addr)
 {
 	char buf[6];
 	int ret;
@@ -391,11 +391,13 @@ char *efuse_get_mac(char *addr)
 	 */
 	ret = efuse_user_attr_show("mac", buf);
 	if (ret < 0) {
-		pr_err("hwmac: error to read MAC address, use default address\n");
-		memcpy(buf, "\xc0\xff\xee\x00\x01\x9f", 6);
+		pr_err("%s: failed to read MAC\n", __func__);
+	} else {
+		printk("%s: %pM\n", __func__, buf);
+		memcpy(addr, buf, 6);
 	}
 
-	return memcpy(addr, buf, 6);
+	return ret;
 }
 EXPORT_SYMBOL(efuse_get_mac);
 

--- a/drivers/amlogic/efuse/efuse64.c
+++ b/drivers/amlogic/efuse/efuse64.c
@@ -381,6 +381,25 @@ error_exit:
 	return ret;
 }
 
+char *efuse_get_mac(char *addr)
+{
+	char buf[6];
+	loff_t offset = 0x34;
+	int ret;
+
+	/* Copy H/W MAC address from eFuse programmed on production.
+	 * If missing or an error, C0:FF:EE:00:01:9F will be used.
+	 */
+	ret = efuse_read_usr(buf, sizeof(buf), &offset);
+	if (ret < 0) {
+		pr_err("hwmac: error to read MAC address, use default address\n");
+		memcpy(buf, "\xc0\xff\xee\x00\x01\x9f", 6);
+	}
+
+	return memcpy(addr, buf, 6);
+}
+EXPORT_SYMBOL(efuse_get_mac);
+
 static ssize_t userdata_show(struct class *cla,
 	struct class_attribute *attr, char *buf)
 {

--- a/drivers/amlogic/efuse/efuse64.c
+++ b/drivers/amlogic/efuse/efuse64.c
@@ -384,13 +384,12 @@ error_exit:
 char *efuse_get_mac(char *addr)
 {
 	char buf[6];
-	loff_t offset = 0x34;
 	int ret;
 
 	/* Copy H/W MAC address from eFuse programmed on production.
 	 * If missing or an error, C0:FF:EE:00:01:9F will be used.
 	 */
-	ret = efuse_read_usr(buf, sizeof(buf), &offset);
+	ret = efuse_user_attr_show("mac", buf);
 	if (ret < 0) {
 		pr_err("hwmac: error to read MAC address, use default address\n");
 		memcpy(buf, "\xc0\xff\xee\x00\x01\x9f", 6);

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -63,7 +63,7 @@
 extern unsigned int g_mac_addr_setup;
 
 #if defined (CONFIG_EFUSE)
-extern char *efuse_get_mac(char *addr);
+extern int efuse_get_mac(char *addr);
 #endif
 
 #define STMMAC_ALIGN(x)	L1_CACHE_ALIGN(x)

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -58,6 +58,13 @@
 #define STMMAC_XMIT_DEBUG
 #endif
 #include <linux/reset.h>
+#include <linux/amlogic/securitykey.h>
+
+extern unsigned int g_mac_addr_setup;
+
+#if defined (CONFIG_EFUSE)
+extern char *efuse_get_mac(char *addr);
+#endif
 
 #define STMMAC_ALIGN(x)	L1_CACHE_ALIGN(x)
 
@@ -2284,6 +2291,28 @@ static void stmmac_init_tx_coalesce(struct stmmac_priv *priv)
 	add_timer(&priv->txtimer);
 }
 
+#if defined (CONFIG_AML_NAND_KEY) || defined (CONFIG_SECURITYKEY)
+static char print_buff[1025];
+int read_mac_from_nand(struct net_device *ndev)
+{
+	int ret;
+	u8 mac[ETH_ALEN];
+	char *endp;
+	int j;
+	ret = get_aml_key_kernel("mac", print_buff, 0);
+	extenal_api_key_set_version("auto");
+	printk("%s: ret = %d print_buff=%s\n", __FUNCTION__, ret, print_buff);
+	if (ret >= 0) {
+		strcpy(ndev->dev_addr, print_buff);
+		for(j = 0; j < ETH_ALEN; j++)
+			mac[j] = simple_strtol(&ndev->dev_addr[3 * j], &endp, 16);
+		memcpy(ndev->dev_addr, mac, ETH_ALEN);
+	}
+
+	return ret;
+}
+#endif
+
 /**
  * stmmac_hw_setup: setup mac in a usable state.
  *  @dev : pointer to the device structure.
@@ -2378,7 +2407,21 @@ static struct delayed_work moniter_tx_worker;
 static int stmmac_open(struct net_device *dev)
 {
 	struct stmmac_priv *priv = netdev_priv(dev);
-	int ret;
+
+	int ret = 0;
+
+	if (g_mac_addr_setup == 0) {
+#if defined (CONFIG_AML_NAND_KEY) || defined (CONFIG_SECURITYKEY)
+		ret = read_mac_from_nand(dev);
+		if (ret < 0)
+#endif
+		{
+#if defined CONFIG_EFUSE
+			efuse_get_mac(dev->dev_addr);
+#endif
+		}
+	}
+
 	stmmac_check_ether_addr(priv);
 
 	if (priv->pcs != STMMAC_PCS_RGMII && priv->pcs != STMMAC_PCS_TBI &&

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -59,6 +59,9 @@
 #endif
 #include <linux/reset.h>
 #include <linux/amlogic/securitykey.h>
+#ifdef CONFIG_AMLOGIC_CPU_INFO
+#include <linux/amlogic/cpu_version.h>
+#endif
 
 extern unsigned int g_mac_addr_setup;
 
@@ -2410,6 +2413,12 @@ static int stmmac_open(struct net_device *dev)
 
 	int ret = 0;
 
+#ifdef CONFIG_AMLOGIC_CPU_INFO
+	static const u8 def_mac[] = {0x00, 0x15, 0x18, 0x01, 0x81, 0x31};
+	unsigned char chipid[16];
+	u8 buf[6];
+#endif
+
 	if (g_mac_addr_setup == 0) {
 #if defined (CONFIG_AML_NAND_KEY) || defined (CONFIG_SECURITYKEY)
 		ret = read_mac_from_nand(dev);
@@ -2417,10 +2426,24 @@ static int stmmac_open(struct net_device *dev)
 #endif
 		{
 #if defined CONFIG_EFUSE
-			efuse_get_mac(dev->dev_addr);
+			ret = efuse_get_mac(dev->dev_addr);
 #endif
 		}
 	}
+
+#ifdef CONFIG_AMLOGIC_CPU_INFO
+	if (ether_addr_equal(priv->dev->dev_addr, def_mac) ||
+	    !is_valid_ether_addr(priv->dev->dev_addr) ||
+	    ret < 0) {
+		printk("%s: generate MAC from CPU serial number\n", __func__);
+		cpuinfo_get_chipid(chipid);
+		memcpy(buf, chipid + 10, 6);
+		buf[0] &= 0xfe;  /* clear multicast bit */
+		buf[0] |= 0x02;  /* set local assignment bit (IEEE802) */
+		printk("%s: generated MAC address: %pM\n", __func__, buf);
+		ether_addr_copy(dev->dev_addr, buf);
+	}
+#endif
 
 	stmmac_check_ether_addr(priv);
 

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
@@ -168,6 +168,10 @@ static int dwmac1000_validate_ucast_entries(int ucast_entries)
 	return x;
 }
 
+#if defined (CONFIG_EFUSE)
+extern char *efuse_get_mac(char *addr);
+#endif
+
 static int platdata_copy_from_machine_data(const struct of_device_id *device,
 					   struct plat_stmmacenet_data *plat)
 {
@@ -195,6 +199,12 @@ static int setup_mac_addr(struct platform_device *pdev, const char **mac)
 {
 	struct device_node *np = pdev->dev.of_node;
 #ifdef CONFIG_DWMAC_MESON
+#if defined (CONFIG_EFUSE)
+	if (g_mac_addr_setup == 0) {
+		efuse_get_mac(DEFMAC);
+		g_mac_addr_setup++;
+	}
+#endif
 	if (g_mac_addr_setup)	/*so uboot mac= is first priority.*/
 		*mac = DEFMAC;
 	else

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
@@ -75,7 +75,7 @@ static const struct of_device_id stmmac_dt_ids[] = {
 MODULE_DEVICE_TABLE(of, stmmac_dt_ids);
 #ifdef CONFIG_DWMAC_MESON
 static u8 DEFMAC[] = {0, 0, 0, 0, 0, 0};
-static unsigned int g_mac_addr_setup;
+unsigned int g_mac_addr_setup = 0;
 static unsigned char chartonum(char c)
 {
 	if (c >= '0' && c <= '9')
@@ -168,10 +168,6 @@ static int dwmac1000_validate_ucast_entries(int ucast_entries)
 	return x;
 }
 
-#if defined (CONFIG_EFUSE)
-extern char *efuse_get_mac(char *addr);
-#endif
-
 static int platdata_copy_from_machine_data(const struct of_device_id *device,
 					   struct plat_stmmacenet_data *plat)
 {
@@ -199,12 +195,6 @@ static int setup_mac_addr(struct platform_device *pdev, const char **mac)
 {
 	struct device_node *np = pdev->dev.of_node;
 #ifdef CONFIG_DWMAC_MESON
-#if defined (CONFIG_EFUSE)
-	if (g_mac_addr_setup == 0) {
-		efuse_get_mac(DEFMAC);
-		g_mac_addr_setup++;
-	}
-#endif
 	if (g_mac_addr_setup)	/*so uboot mac= is first priority.*/
 		*mac = DEFMAC;
 	else


### PR DESCRIPTION
This set of patches adds the following:
* reading MAC address from eFuse
* reading MAC address from NAND-key
* generating MAC address from SoC serial number if there is no valid MAC provided by any previous reads
* make sure that device doesn't use "default" Amlogic MAC address to avoid having duplicate MAC on many devices

Most devices provide MAC in cmdline but some of them, e.g. Khadas VIM, Le Potato don't. This set of patches allows us to look for hardware MAC in all places it can possibly exist and if no valid address is found, we generate one from SoC serial number to make sure it stays consistent between reboots.