### PR TITLE
3.14 kernel compile fixes after Nougat merge

### DIFF
--- a/drivers/amlogic/amports/vdec.c
+++ b/drivers/amlogic/amports/vdec.c
@@ -1325,6 +1325,7 @@ s32 vdec_init(struct vdec_s *vdec, int is_4k)
 			goto error;
 		}
 		if (p->frame_base_video_path == FRAME_BASE_PATH_IONVIDEO) {
+#ifdef CONFIG_AMLOGIC_IONVIDEO
 #if 1
 			r = ionvideo_assign_map(&vdec->vf_receiver_name,
 					&vdec->vf_receiver_inst);
@@ -1349,6 +1350,7 @@ s32 vdec_init(struct vdec_s *vdec, int is_4k)
 
 				goto error;
 			}
+#endif
 
 			snprintf(vdec->vfm_map_chain, VDEC_MAP_NAME_SIZE,
 				"%s %s", vdec->vf_provider_name,

--- a/drivers/amlogic/amports/vvp9.c
+++ b/drivers/amlogic/amports/vvp9.c
@@ -5697,8 +5697,8 @@ static int prepare_display_buf(struct VP9Decoder_s *pbi,
 			pbi->vf_pre_count++;
 #ifndef CONFIG_MULTI_DEC
 			/*count info*/
-			gvs->frame_dur = pbi->frame_dur;
-			vdec_count_info(gvs, 0, stream_offset);
+			pbi->gvs->frame_dur = pbi->frame_dur;
+			vdec_count_info(pbi->gvs, 0, stream_offset);
 #endif
 			vf_notify_receiver(pbi->provider_name,
 			VFRAME_EVENT_PROVIDER_VFRAME_READY, NULL);
@@ -6460,15 +6460,17 @@ int vvp9_dec_status(struct vdec_s *vdec, struct vdec_info *vstatus)
 	vstatus->status = vp9->stat | vp9->fatal_error;
 	vstatus->frame_dur = vp9->frame_dur;
 #ifndef CONFIG_MULTI_DEC
-	vstatus->bit_rate = gvs->bit_rate;
-	vstatus->frame_data = gvs->frame_data;
-	vstatus->total_data = gvs->total_data;
-	vstatus->frame_count = gvs->frame_count;
-	vstatus->error_frame_count = gvs->error_frame_count;
-	vstatus->drop_frame_count = gvs->drop_frame_count;
-	vstatus->total_data = gvs->total_data;
-	vstatus->samp_cnt = gvs->samp_cnt;
-	vstatus->offset = gvs->offset;
+	if (vp9->gvs) {
+		vstatus->bit_rate = vp9->gvs->bit_rate;
+		vstatus->frame_data = vp9->gvs->frame_data;
+		vstatus->total_data = vp9->gvs->total_data;
+		vstatus->frame_count = vp9->gvs->frame_count;
+		vstatus->error_frame_count = vp9->gvs->error_frame_count;
+		vstatus->drop_frame_count = vp9->gvs->drop_frame_count;
+		vstatus->total_data = vp9->gvs->total_data;
+		vstatus->samp_cnt = vp9->gvs->samp_cnt;
+		vstatus->offset = vp9->gvs->offset;
+	}
 	snprintf(vstatus->vdec_name, sizeof(vstatus->vdec_name),
 		"%s", DRIVER_NAME);
 #endif

--- a/drivers/amlogic/pwm/pwm_meson.c
+++ b/drivers/amlogic/pwm/pwm_meson.c
@@ -44,6 +44,7 @@ void pwm_write_reg(void __iomem *reg,
 	tmp |= val;
 	writel(tmp, reg);
 };
+EXPORT_SYMBOL(pwm_write_reg);
 
 void pwm_clear_reg_bits(void __iomem *reg, const unsigned int val)
 {
@@ -52,6 +53,7 @@ void pwm_clear_reg_bits(void __iomem *reg, const unsigned int val)
 	tmp = orig & ~val;
 	writel(tmp, reg);
 }
+EXPORT_SYMBOL(pwm_clear_reg_bits);
 
 void pwm_write_reg1(void __iomem *reg, const unsigned int  val)
 {
@@ -66,6 +68,7 @@ struct aml_pwm_chip *to_aml_pwm_chip(struct pwm_chip *chip)
 {
 	return container_of(chip, struct aml_pwm_chip, chip);
 }
+EXPORT_SYMBOL(to_aml_pwm_chip);
 
 static
 struct aml_pwm_channel *pwm_aml_calc(struct aml_pwm_chip *chip,


### PR DESCRIPTION
This PR fixes compiling when using kernel options a bit different than "suggested" by meson64_defconfig.

Please do not merge yet, VP9 patch needs to be runtime-tested.