### PR TITLE
[3.14] Enable autorepeat for Amlogic IR remote

### DIFF
--- a/drivers/amlogic/input/remote/remote_core.c
+++ b/drivers/amlogic/input/remote/remote_core.c
@@ -202,6 +202,7 @@ int remote_register_device(struct remote_dev *dev)
 	}
 
 	__set_bit(EV_KEY, dev->input_device->evbit);
+	__set_bit(EV_REP, dev->input_device->evbit);
 
 	for (i = 0; i < KEY_MAX; i++)
 		__set_bit(i, dev->input_device->keybit);

--- a/drivers/amlogic/input/remote/remote_meson.c
+++ b/drivers/amlogic/input/remote/remote_meson.c
@@ -588,8 +588,6 @@ static void ir_input_device_init(struct input_dev *dev,
 	dev->id.vendor  = 0x0001;
 	dev->id.product = 0x0001;
 	dev->id.version = 0x0100;
-	dev->rep[REP_DELAY] = 0xffffffff;  /*close input repeat*/
-	dev->rep[REP_PERIOD] = 0xffffffff; /*close input repeat*/
 }
 
 static int remote_probe(struct platform_device *pdev)


### PR DESCRIPTION
Enable autorepeat in new Amlogic driver for IR remote.