### PR TITLE
fix in-kernel decoding with meson-ir

### DIFF
--- a/drivers/media/rc/ir-nec-decoder.c
+++ b/drivers/media/rc/ir-nec-decoder.c
@@ -145,7 +145,17 @@ static int ir_nec_decode(struct rc_dev *dev, struct ir_raw_event ev)
 		if (!ev.pulse)
 			break;
 
-		if (!geq_margin(ev.duration, NEC_TRAILER_PULSE, NEC_UNIT / 2))
+		if (!eq_margin(ev.duration, NEC_TRAILER_PULSE, NEC_UNIT / 2))
+			break;
+
+		data->state = STATE_TRAILER_SPACE;
+		return 0;
+
+	case STATE_TRAILER_SPACE:
+		if (ev.pulse)
+			break;
+
+		if (!geq_margin(ev.duration, NEC_TRAILER_SPACE, NEC_UNIT / 2))
 			break;
 
 		address     = bitrev8((data->bits >> 24) & 0xff);

--- a/drivers/media/rc/rc-main.c
+++ b/drivers/media/rc/rc-main.c
@@ -31,7 +31,7 @@ DECLARE_BITMAP(ir_core_dev_number, IRRCV_NUM_DEVICES);
 #define IR_TAB_MAX_SIZE	8192
 
 /* FIXME: IR_KEYPRESS_TIMEOUT should be protocol specific */
-#define IR_KEYPRESS_TIMEOUT 150
+#define IR_KEYPRESS_TIMEOUT 250
 
 /* Used to keep track of known keymaps */
 static LIST_HEAD(rc_map_list);


### PR DESCRIPTION
reverted 2 problematic local commits which partially fixed NEC decoding and broke timeout handling and instead implemented proper timeout handling in meson-ir so it can be used with all in-kernel protocol decoders