### PR TITLE
arch/arm64/boot/dts/amlogic: clean up DVFS table for GXM GPU and enable 800MHz

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxm_pxp.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_pxp.dts
@@ -1124,6 +1124,3 @@
 &defendkey {
 	status = "okay";
 };
-&t82x_gpu {
-        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs666_cfg>;
-};

--- a/arch/arm64/boot/dts/amlogic/gxm_q200_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_q200_2g.dts
@@ -1183,6 +1183,3 @@
 &defendkey {
 	status = "okay";
 };
-&t82x_gpu {
-        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs666_cfg>;
-};

--- a/arch/arm64/boot/dts/amlogic/gxm_q201_1g.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_q201_1g.dts
@@ -1154,6 +1154,3 @@
 &defendkey {
 	status = "okay";
 };
-&t82x_gpu {
-        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs666_cfg>;
-};

--- a/arch/arm64/boot/dts/amlogic/gxm_q201_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_q201_2g.dts
@@ -1170,6 +1170,3 @@
 &defendkey {
 	status = "okay";
 };
-&t82x_gpu {
-        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs666_cfg>;
-};

--- a/arch/arm64/boot/dts/amlogic/gxm_skt.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_skt.dts
@@ -1187,6 +1187,3 @@
 &defendkey {
 	status = "okay";
 };
-&t82x_gpu {
-        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs666_cfg>;
-};

--- a/arch/arm64/boot/dts/amlogic/mesongxm-gpu-t82x.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxm-gpu-t82x.dtsi
@@ -24,6 +24,7 @@
         /*mali-supply = <&vdd_mali>;*/
         operating-points = <
             /* KHz   uV */
+            792000 1000000
             666666 1000000
             500000 1000000
             400000 1000000
@@ -32,7 +33,7 @@
             125000 1000000
         >;
 
-        tbl = <&dvfs125_cfg &dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg>;
+        tbl = <&dvfs285_cfg &dvfs400_cfg &dvfs500_cfg &dvfs666_cfg &dvfs800_cfg &dvfs800_cfg>;
 
         /*clocks = <&gpu_clk>;
         clock-names = "clk_mali";*/


### PR DESCRIPTION
All GXM device trees have the same DVFS table, we can move it to commom dtsi.

This patch also enables GPU to run at 792MHz.

Patch verified using performance governor for both CPU and GPU + glmark2 offscreen for several minutes.