### PR TITLE
amlogic/bluetooth: Turn BT device on after probe

### DIFF
--- a/drivers/amlogic/bluetooth/bt_device.c
+++ b/drivers/amlogic/bluetooth/bt_device.c
@@ -273,6 +273,7 @@ static int bt_probe(struct platform_device *pdev)
 	register_early_suspend(&bt_early_suspend);
 #endif
 
+	bt_device_on(pdata);
 	return 0;
 
 err_rfkill:


### PR DESCRIPTION
Upstreaming https://github.com/LibreELEC/LibreELEC.tv/blob/master/projects/WeTek_Play_2/patches/linux/bt_device_on_after_probe.patch
