### PR TITLE
Add an option to force request the Power ON state after a resume when wake locks and early suspend are enabled

### DIFF
--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -59,6 +59,14 @@ config EARLYSUSPEND
 		Call early suspend handlers when the user requested sleep state
 		changes.
 
+config FORCE_POWER_ON_STATE_AFTER_RESUME
+	bool "Force to request the Power ON state after a resume"
+	depends on WAKELOCK && EARLYSUSPEND
+	default n
+	help
+	  Force to request the Power ON state after a resume, causing to execute the late resume
+	  and prevent transition back into the suspended state.
+
 choice
 	prompt "User-space screen access"
 	default FB_EARLYSUSPEND if !FRAMEBUFFER_CONSOLE

--- a/kernel/power/wakelock_android.c
+++ b/kernel/power/wakelock_android.c
@@ -318,6 +318,9 @@ static void suspend(struct work_struct *work)
 
 	}
 	wake_lock_timeout(&unknown_wakeup, 5 * HZ);
+#ifdef CONFIG_FORCE_POWER_ON_STATE_AFTER_RESUME
+	request_suspend_state(PM_SUSPEND_ON);
+#endif
 }
 
 static DECLARE_WORK(suspend_work, suspend);


### PR DESCRIPTION
Alternative to https://github.com/LibreELEC/linux-amlogic/pull/6

Cherry-picked from https://github.com/LibreELEC/linux-amlogic/commit/3c6d2d2869aad69dde8ec4483a184e739b5e4739#diff-4bc504812a6e5edefe9068b56aa3ddf0

This is one of the puzzle pieces to make suspend+wakeup work. 

This patch has been present in my community builds, no side effects observed, suspend reported to work on some S905X and S912 devices.