### PR TITLE
Add meson-ir support for gxl and gxm, make it default

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
@@ -606,7 +606,7 @@
 		dev_name = "meson-remote";
 		reg = <0x0 0xc8100580 0x00 0x44>, /*Multi-format IR controller*/
 			<0x0 0xc8100480 0x00 0x20>; /*Legacy IR controller*/
-		status = "okay";
+		status = "disabled";
 		protocol = <REMOTE_TYPE_NEC>;
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";
@@ -732,7 +732,7 @@
 
 	meson_ir:meson-ir {
 		compatible = "amlogic,meson-gxbb-ir";
-		status = "disabled";
+		status = "okay";
 		reg = <0x0 0xc8100580 0x0 0x40>;
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
@@ -692,7 +692,7 @@
 		dev_name = "meson-remote";
 		reg = <0x0 0xc8100580 0x00 0x44>, /*Multi-format IR controller*/
 			<0x0 0xc8100480 0x00 0x20>; /*Legacy IR controller*/
-		status = "okay";
+		status = "disabled";
 		protocol = <REMOTE_TYPE_NEC>;
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";
@@ -850,6 +850,15 @@
 				REMOTE_KEY(0x9a,120)
 				REMOTE_KEY(0xcd,121)>;
 		};
+	};
+
+	meson_ir:meson-ir {
+		compatible = "amlogic,meson-gxbb-ir";
+		status = "okay";
+		reg = <0x0 0xc8100580 0x0 0x40>;
+		interrupts = <0 196 1>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&remote_pins>;
 	};
 
 	rng {

--- a/arch/arm64/boot/dts/amlogic/mesongxm.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxm.dtsi
@@ -767,7 +767,7 @@
 		dev_name = "meson-remote";
 		reg = <0x0 0xc8100580 0x00 0x44>, /*Multi-format IR controller*/
 			<0x0 0xc8100480 0x00 0x20>; /*Legacy IR controller*/
-		status = "okay";
+		status = "disabled";
 		protocol = <REMOTE_TYPE_NEC>;
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";
@@ -914,6 +914,15 @@
 				REMOTE_KEY(0xcd,121)>;
 		};
  	};
+
+	meson_ir:meson-ir {
+		compatible = "amlogic,meson-gxbb-ir";
+		status = "okay";
+		reg = <0x0 0xc8100580 0x0 0x40>;
+		interrupts = <0 196 1>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&remote_pins>;
+	};
 
 	rng {
 		compatible = "amlogic,meson-rng";


### PR DESCRIPTION
As we want to make meson-ir our default IR driver, this PR adds support for S905X and S912 devices and enables meson-ir as default solution instead of amremote (except for WP2).

To be verified on S912 (gxm), thus "do not merge".