### PR TITLE
arch/arm64/boot/dts/amlogic: resize SYSTEM partition to 512MB

### DIFF
--- a/arch/arm64/boot/dts/amlogic/partition_mbox.dtsi
+++ b/arch/arm64/boot/dts/amlogic/partition_mbox.dtsi
@@ -59,7 +59,7 @@
 		system:system
 		{
 			pname = "system";
-			size = <0x0 0x80000000>;
+			size = <0x0 0x20000000>;
 			mask = <1>;
 		};
 		cache:cache


### PR DESCRIPTION
To apply new partition layout user needs to write device tree to /dev/dtb, reboot (for u-boot to apply the changes) and format partitions.

Partition layout varies from device to device and from one kernel release to another, so above action is needed anyway. Resizing partitions to our needs gives user 512MB to 1.5GB more space for "data".

I wanted to get rid of other partitions but deleting them makes Amlogic u-boot go crazy - this approach is the safest.