### PR TITLE
arch/arm64/boot/dts/amlogic: increase framebuffer reserved memory se for S905W

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxl_p281_1g.dts
+++ b/arch/arm64/boot/dts/amlogic/gxl_p281_1g.dts
@@ -67,7 +67,7 @@
 		};
 		fb_reserved:linux,meson-fb {
 			compatible = "amlogic, fb-memory";
-			reg = <0x0 0x3f000000 0x0 0x1000000>;
+			reg = <0x0 0x3e000000 0x0 0x2000000>;
 			no-map;
 		};
 
@@ -177,11 +177,11 @@
 		interrupts = <0 3 1
 			0 89 1>;
 		interrupt-names = "viu-vsync", "rdma";
-		mem_size = <0x00b00000 0x00100000>; /* fb0/fb1 memory size */
-		display_mode_default = "720p60hz";
+		mem_size = <0x01851000 0x00100000>; /* fb0/fb1 memory size */
+		display_mode_default = "1080p60hz";
 		scale_mode = <1>; /** 0:VPU free scale 1:OSD free scale 2:OSD super scale */
-		display_size_default = <1280 720 1280 2160 32>; //1920*1080*4*3 = 0x17BB000
-		logo_addr = "0x3fb00000";
+		display_size_default = <1920 1080 1920 3240 32>; //1920*1080*4*3 = 0x17BB000
+		logo_addr = "0x3f851000";
 	};
 	ge2d {
 		compatible = "amlogic, ge2d";


### PR DESCRIPTION
This is required to render GUI at 1080p. Values are copied from gxl_p212_1g device tree.