### PR TITLE
[3.14] Fix VP9 memory usage and stutters

### DIFF
--- a/drivers/amlogic/amports/vvp9.c
+++ b/drivers/amlogic/amports/vvp9.c
@@ -2233,7 +2233,7 @@ static u32 dynamic_buf_num_margin;
 #else
 static u32 buf_alloc_width;
 static u32 buf_alloc_height;
-static u32 dynamic_buf_num_margin = 16;
+static u32 dynamic_buf_num_margin = 7;
 #endif
 static u32 buf_alloc_depth = 10;
 static u32 buf_alloc_size;


### PR DESCRIPTION
Partially revert "amports: optimise hevc & vp9 playback"

Bumping dynamic_buf_margin does not do any good for VP9.

This reverts commit 135d9b0e343c47f5d1aa255fb9e2a02f144f7b54.