### PR TITLE
dts: wetek_play: add dev_name property to dvb node to identify the device as wetek-dvb

### DIFF
--- a/arch/arm/boot/dts/amlogic/wetek_play.dtd
+++ b/arch/arm/boot/dts/amlogic/wetek_play.dtd
@@ -1374,6 +1374,7 @@ void root_func(){
 //$$ L2 PROP_CHOICE "dvb_s_ts2_pins_match" = "pinctrl-1"
 	dvb{
 		compatible = "amlogic,dvb";
+		dev_name = "wetek-dvb";
 		/*"parallel","serial","disable"*/
 		ts2 = "parallel";
 		ts2_control = <0>;


### PR DESCRIPTION
Add dev_name property to dvb node of WeTek Play device tree to identify the DVB device as wetek-dvb.

This is required to make https://github.com/LibreELEC/LibreELEC.tv/pull/2579 work on WeTek Play 1.