### PR TITLE
dvb-aml: add support for serial data transfer from avl6862

### DIFF
--- a/drivers/amlogic/dvb-avl/aml_dvb.h
+++ b/drivers/amlogic/dvb-avl/aml_dvb.h
@@ -243,6 +243,7 @@ struct aml_dvb {
 	struct timer_list    watchdog_timer;
 	int                  dmx_watchdog_disable[DMX_DEV_COUNT];
 	struct aml_swfilter  swfilter;
+	int		     ts_out_invert;
 };
 
 

--- a/drivers/amlogic/dvb-avl/aml_fe.c
+++ b/drivers/amlogic/dvb-avl/aml_fe.c
@@ -73,6 +73,7 @@ static struct r848_config r848_config = {
 static struct avl6862_config avl6862_config = {
 	.demod_address = 0x14,
 	.tuner_address = 0x7A,
+	.ts_serial = 0,
 };
 
 int avl6862_Reset(void)
@@ -113,11 +114,13 @@ static int avl6862_fe_init(struct aml_dvb *advb, struct platform_device *pdev, s
 	pr_inf("Init AVL6862 frontend %d\n", id);
 	
 #ifdef CONFIG_OF
+	of_property_read_u32(pdev->dev.of_node, "fe0_ts", &avl6862_config.ts_serial);
+	pr_dbg("fe0_ts=%d\n", avl6862_config.ts_serial);
 	if (of_property_read_u32(pdev->dev.of_node, "dtv_demod0_i2c_adap_id", &i2c_adap_id)) {
 		ret = -ENOMEM;
 		goto err_resource;
 	}
-	pr_dbg("i2c_adap_id=%d\n", &i2c_adap_id);
+	pr_dbg("i2c_adap_id=%d\n", i2c_adap_id);
 	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_reset_gpio-gpios", 0, NULL);
 	gpio_reset = desc_to_gpio(desc);
 	pr_dbg("gpio_reset=%d\n", gpio_reset);
@@ -125,6 +128,13 @@ static int avl6862_fe_init(struct aml_dvb *advb, struct platform_device *pdev, s
 	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_power_gpio-gpios", 0, NULL);
 	gpio_power = desc_to_gpio(desc);
 	pr_dbg("gpio_power=%d\n", gpio_power);
+
+	avl6862_config.gpio_lock_led =0;
+	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_lock_gpio-gpios", 0, NULL);
+	if (!PTR_RET(desc)) {
+	  avl6862_config.gpio_lock_led = desc_to_gpio(desc);
+	  pr_dbg("gpio_lock_led=%d\n", avl6862_config.gpio_lock_led);
+        }
 #endif /*CONFIG_OF*/
 
 	frontend_reset = gpio_reset;

--- a/drivers/amlogic/dvb-avl/avl6862.h
+++ b/drivers/amlogic/dvb-avl/avl6862.h
@@ -23,22 +23,7 @@
 #include "dvb_frontend.h"
 
 #define MAX_CHANNEL_INFO 256
-#if 0
-typedef struct s_DVBTx_Channel_TS
-{
-    // number, example 474*1000 is RF frequency 474MHz.
-    int channel_freq_khz;
-    // number, example 8000 is 8MHz bandwith channel.
-    int channel_bandwith_khz;
 
-    u8 channel_type;
-    // 0 - Low priority layer, 1 - High priority layer
-    u8 dvbt_hierarchy_layer;
-    // data PLP id, 0 to 255; for single PLP DVBT2 channel, this ID is 0; for DVBT channel, this ID isn't used.
-    u8 data_plp_id;
-    u8 channel_profile;
-}s_DVBTx_Channel_TS;
-#endif
 struct avl6862_priv {
 	struct i2c_adapter *i2c;
  	struct avl6862_config *config;
@@ -47,18 +32,18 @@ struct avl6862_priv {
 
 	/* DVB-Tx */
 	u16 g_nChannel_ts_total;
-//	s_DVBTx_Channel_TS global_channel_ts_table[MAX_CHANNEL_INFO];
 };
 
 struct avl6862_config {
-	int		i2c_id; // i2c adapter id
-	void	*i2c_adapter; // i2c adapter
+	int		i2c_id;        // i2c adapter id
+	void		*i2c_adapter;  // i2c adapter
 	u8		demod_address; // demodulator i2c address
 	u8		tuner_address; // tuner i2c address
-	unsigned char eDiseqcStatus;
+	unsigned char 	eDiseqcStatus;
+	int             ts_serial;
+	int		gpio_lock_led;
 };
 
 extern struct dvb_frontend *avl6862_attach(struct avl6862_config *config, struct i2c_adapter *i2c);
-extern struct dvb_frontend *avl6862x_attach(struct avl6862_config *config, struct i2c_adapter *i2c);
 
 #endif /* AVL6862_H */

--- a/drivers/amlogic/dvb-avl/c_stb_define.h
+++ b/drivers/amlogic/dvb-avl/c_stb_define.h
@@ -91,6 +91,7 @@
 /*  7:0 -- fec_sync_byte (default : 0x47)*/
 /*#define TS_TOP_CONFIG           (STB_CBUS_BASE + 0xf1) // 0x16f1*/
 /*----------- bit define -----------*/
+#define TS_OUT_CLK_INVERT	    16
 #define TS_PACKAGE_LENGTH_SUB_1     8
 #define FEC_DEFAULT_SYNC_BYTE       0
 


### PR DESCRIPTION
Current driver for AVL6882 support only parallel data transfer from demodulator. This PR  adds serial data transfer to support VTV board for Khadas VIM2.