### PR TITLE
arch/arm64/boot/dts/amlogic: 8.2 partition layout

### DIFF
--- a/arch/arm64/boot/dts/amlogic/partition_mbox.dtsi
+++ b/arch/arm64/boot/dts/amlogic/partition_mbox.dtsi
@@ -7,18 +7,19 @@
  *
  */
  / {
-    partitions: partitions{
-        parts = <10>;
+	partitions: partitions{
+        parts = <11>;
 		part-0 = <&logo>;
 		part-1 = <&recovery>;
 		part-2 = <&rsv>;
 		part-3 = <&tee>;
 		part-4 = <&crypt>;
 		part-5 = <&misc>;
-		part-6 = <&boot>;
-		part-7 = <&system>;
-		part-8 = <&cache>;
-		part-9 = <&data>;
+		part-6 = <&instaboot>;
+		part-7 = <&boot>;
+		part-8 = <&system>;
+		part-9 = <&cache>;
+		part-10 = <&data>;
 
 		logo:logo{
 			pname = "logo";
@@ -50,6 +51,11 @@
 			size = <0x0 0x2000000>;
 			mask = <1>;
 		};
+		instaboot:instaboot{
+			pname = "instaboot";
+			size = <0x0 0x20000000>;
+			mask = <1>;
+		};
 		boot:boot
 		{
 			pname = "boot";
@@ -59,7 +65,7 @@
 		system:system
 		{
 			pname = "system";
-			size = <0x0 0x20000000>;
+			size = <0x0 0x40000000>;
 			mask = <1>;
 		};
 		cache:cache


### PR DESCRIPTION
This PR changes the partition layout for DTB's for S905/S912.

This will prevent devices from bricking where users are installed on internal when upgrading from one 8.2/8.90 community releases.