### PR TITLE
Add KVIM2  VTV board support in avl6862 driver.

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxm_kvim2.dts
+++ b/arch/arm64/boot/dts/amlogic/gxm_kvim2.dts
@@ -1,0 +1,129 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_kvim2";
+	compatible = "kvim";
+	amlogic-dt-id = "kvim";
+
+	memory@00000000 {
+		/delete-property/ linux,usable-memory;
+		linux,usable-memory-2g = <0x0 0x00100000 0x0 0x7ff00000>;
+		linux,usable-memory-3g = <0x0 0x00100000 0x0 0xbff00000>;
+	};
+
+	sysled {
+		led_gpio = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_HIGH>;
+	};
+
+	fan {
+		compatible = "fanctl";
+		fan_ctl0 = <&gpio GPIODV_14 GPIO_ACTIVE_HIGH>;
+		fan_ctl1 = <&gpio GPIODV_15 GPIO_ACTIVE_HIGH>;
+		trig_temp_level0 = <50>;
+		trig_temp_level1 = <60>;
+		trig_temp_level2 = <70>;
+	};
+
+	meson-fb {
+		/delete-property/ logo_addr;
+		logo_addr_2g = "0x7d851000";
+		logo_addr_3g = "0xbd851000"; /*ion base + fb0 memory size for uboot logo osd1*/
+	};
+
+	uart_AO_B: serial@c81004e0 {
+		status = "okay";
+	};
+	
+	dwc2_a {
+		controller-type = <2>; /** 0: normal, 1: otg+dwc3 host only, 2: otg+dwc3 device only*/
+	};
+	adc_keypad{
+		compatible = "amlogic, adc_keypad";
+		status = "okay";
+		key_name = "home";
+		key_num = <1>;
+		key_code = <102>;
+		key_chan = <0>;
+		key_val = <10>;
+		key_tolerance = <40>;
+	};
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "serial";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_12 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+ 		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio  GPIODV_12  GPIO_ACTIVE_HIGH>;
+		dtv_demod0_power_gpio-gpios = <&gpio  GPIODV_20  GPIO_ACTIVE_HIGH>;
+		dtv_demod0_lock_gpio-gpios = <&gpio  GPIODV_11  GPIO_ACTIVE_HIGH>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <1>;
+		fe0_dev = <0>;
+	};
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+	rtc_hym8563{
+			compatible = "amlogic, rtc_hym8563";
+			dev_name = "rtc_hym8563";
+			status = "okay";
+		reg = <0x51>;
+	};
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask=<1 0xC2000000 2 0xC00400 3 0xA0>;
+		amlogic,pins = "GPIODV_11", "GPIODV_12", "GPIODV_20";
+	};
+};

--- a/drivers/amlogic/amports/esparser.c
+++ b/drivers/amlogic/amports/esparser.c
@@ -430,7 +430,7 @@ s32 esparser_init(struct stream_buf_s *buf, struct vdec_s *vdec)
 
 		/* TS data path */
 #ifndef CONFIG_AM_DVB
-		WRITE_DEMUX_REG(FEC_INPUT_CONTROL, 0);
+//		WRITE_DEMUX_REG(FEC_INPUT_CONTROL, 0);
 #else
 		tsdemux_set_reset_flag();
 #endif

--- a/drivers/amlogic/dvb-avl/aml_dmx.c
+++ b/drivers/amlogic/dvb-avl/aml_dmx.c
@@ -1152,6 +1152,7 @@ static void dvr_process_channel(struct aml_asyncfifo *afifo,
 {
 	int cnt;
 	int ret = 0;
+	pr_dbg_irq_dvr("buf_read:%d buf_toggle:%d\n", afifo->buf_read, afifo->buf_toggle);
 
 	if (afifo->buf_read > afifo->buf_toggle) {
 		cnt = total - afifo->buf_read;
@@ -1159,6 +1160,7 @@ static void dvr_process_channel(struct aml_asyncfifo *afifo,
 				afifo->pages_map+afifo->buf_read*size,
 				cnt*size,
 				DMA_FROM_DEVICE);
+		pr_dbg_irq_dvr("DMA_sync_single_for_cpu cnt:%d size:%d\n", cnt, size);
 		if (sf)
 			ret = _rbuf_write(&sf->rbuf,
 					(u8 *)afifo->pages+afifo->buf_read*size,
@@ -1177,6 +1179,7 @@ static void dvr_process_channel(struct aml_asyncfifo *afifo,
 				afifo->pages_map+afifo->buf_read*size,
 				cnt*size,
 				DMA_FROM_DEVICE);
+		pr_dbg_irq_dvr("dma_sync_single_for_cpu cnt:%d size:%d\n", cnt, size);
 		if (sf) {
 			if (ret >= 0)
 				ret = _rbuf_write(&sf->rbuf,
@@ -1209,7 +1212,7 @@ static void dvr_irq_bh_handler(unsigned long arg)
 	int i, factor;
 	unsigned long flags;
 
-	pr_dbg_irq_dvr("async fifo %d irq:%d, %d\n", afifo->id, afifo->asyncfifo_irq, afifo->buf_toggle);
+	pr_dbg_irq_dvr("async fifo %d irq:%d, %d source:%d\n", afifo->id, afifo->asyncfifo_irq, afifo->buf_toggle, afifo->source);
 
 	spin_lock_irqsave(&dvb->slock, flags);
 
@@ -1227,8 +1230,7 @@ static void dvr_irq_bh_handler(unsigned long arg)
 				issf = 1;
 
 			for (i = 0; i < CHANNEL_COUNT; i++) {
-				if (dmx->channel[i].used
-						&& dmx->channel[i].dvr_feed) {
+				if (dmx->channel[i].used && dmx->channel[i].dvr_feed) {
 					dvr_process_channel(afifo,
 							&dmx->channel[i],
 							total,
@@ -1258,23 +1260,22 @@ static irqreturn_t dvr_irq_handler(int irq_number, void *para)
 /*Enable the STB*/
 static void stb_enable(struct aml_dvb *dvb)
 {
-	int out_src, des_in, en_des, fec_clk, hiu, dec_clk_en;
+	int out_src, des_in = 0, en_des = 0, fec_clk, hiu, dec_clk_en = 0;
 	int src, tso_src, i;
 	u32 fec_s0, fec_s1;
 	u32 invert0, invert1;
 
+	u32 data;
 	switch (dvb->stb_source) {
 	case AM_TS_SRC_DMX0:
 		src = dvb->dmx[0].source;
 		break;
-//
 	case AM_TS_SRC_DMX1:
 		src = dvb->dmx[1].source;
 		break;
 	case AM_TS_SRC_DMX2:
 		src = dvb->dmx[2].source;
 		break;
-//
 	default:
 		src = dvb->stb_source;
 		break;
@@ -1315,40 +1316,17 @@ static void stb_enable(struct aml_dvb *dvb)
 		break;
 	}
 
-	switch (dvb->dsc_source+7) {
-	case AM_TS_SRC_DMX0:
-		des_in = 0;
-		en_des = 1;
-		dec_clk_en = 1;
-		break;
-	case AM_TS_SRC_DMX1:
-		des_in = 1;
-		en_des = 1;
-		dec_clk_en = 1;
-		break;
-	case AM_TS_SRC_DMX2:
-		des_in = 2;
-		en_des = 1;
-		dec_clk_en = 1;
-		break;
-	default:
-		des_in = 0;
-		en_des = 0;
-		dec_clk_en = 0;
-		break;
-	}
-
 	switch (dvb->tso_source) {
 	case AM_TS_SRC_DMX0:
 		tso_src = dvb->dmx[0].source;
 		break;
-/**/	case AM_TS_SRC_DMX1:
+	case AM_TS_SRC_DMX1:
 		tso_src = dvb->dmx[1].source;
 		break;
 	case AM_TS_SRC_DMX2:
 		tso_src = dvb->dmx[2].source;
 		break;
-/**/	default:
+	default:
 		tso_src = dvb->tso_source;
 		break;
 	}
@@ -1364,9 +1342,11 @@ static void stb_enable(struct aml_dvb *dvb)
 		out_src = 2;
 		break;
 	case AM_TS_SRC_S_TS0:
+		out_src = 6;
+		break;
 	case AM_TS_SRC_S_TS1:
 	case AM_TS_SRC_S_TS2:
-		out_src = 6;
+		out_src = 5;
 		break;
 	case AM_TS_SRC_HIU:
 		out_src = 7;
@@ -1376,7 +1356,7 @@ static void stb_enable(struct aml_dvb *dvb)
 		break;
 	}
 
-	pr_dbg("[stb]src: %d, dsc1in: %d, tso: %d\n", src, des_in, out_src);
+	pr_dbg("[stb]src:%d tso:%d out_src:%d\n", src, tso_src, out_src);
 
 	fec_s0 = 0;
 	fec_s1 = 0;
@@ -1392,6 +1372,7 @@ static void stb_enable(struct aml_dvb *dvb)
 
 	invert0 = dvb->s2p[0].invert;
 	invert1 = dvb->s2p[1].invert;
+	pr_dbg("fec_s0:%d, invert0:%d fec_s1:%d invert1:%d en_des:%d\n", fec_s0, invert0, fec_s1, invert1, en_des);
 
 	WRITE_MPEG_REG(STB_TOP_CONFIG,
 		       (invert1 << INVERT_S2P1_FEC_CLK) |
@@ -1405,7 +1386,14 @@ static void stb_enable(struct aml_dvb *dvb)
 
 	if (dvb->reset_flag)
 		hiu = 0;
-
+	/* invert ts out clk,add ci model need add this*/
+	if (dvb->ts_out_invert) {
+		/*printk("ts out invert ---\r\n");*/
+		data = READ_MPEG_REG(TS_TOP_CONFIG);
+		data |= 1 << TS_OUT_CLK_INVERT;
+		WRITE_MPEG_REG(TS_TOP_CONFIG, data);
+	}
+	/* invert ts out clk  end */
 	WRITE_MPEG_REG(TS_FILE_CONFIG,
 		       (demux_skipbyte << 16) |
 		       (6 << DES_OUT_DLY) |
@@ -1875,6 +1863,7 @@ static int dmx_init(struct aml_dmx *dmx)
 		irq = request_irq(dmx->dmx_irq,	dmx_irq_handler,
 				IRQF_SHARED|IRQF_TRIGGER_RISING,
 				"dmx irq", dmx);
+		pr_dbg("request_irq:%d\n", dmx->dmx_irq);
 	}
 
 	/*Allocate buffer */
@@ -2009,6 +1998,7 @@ static int dmx_get_record_flag(struct aml_dmx *dmx)
 	}
 
 find_done:
+	pr_dbg("channel:%d record_flag:%d linked:%d\n", i, record_flag, linked);
 	return record_flag;
 }
 
@@ -2084,65 +2074,79 @@ static int dmx_enable(struct aml_dmx *dmx)
 //		&& ((dvb->dsc_source-AM_TS_SRC_DMX0)== dmx->id))
 //		fec_core_sel = 1;
 
-	pr_dbg("[dmx-%d]src: %d, rec: %d, hi_bsf: %d, dsc: %d\n",
-			dmx->id, dmx->source, record, hi_bsf, fec_core_sel);
+	pr_dbg("dmx->source:%d fec_sel:%d fec_core_sel:%d record:%d hi_bsf:%d dmx->dump_ts_select:%d\n",
+		dmx->source, fec_sel, fec_core_sel, record, hi_bsf, dmx->dump_ts_select);
 
 	if (dmx->chan_count) {
-		if (set_stb) {
-			u32 v = READ_MPEG_REG(STB_TOP_CONFIG);
-			int i;
+	    if (set_stb) {
+		u32 v = READ_MPEG_REG(STB_TOP_CONFIG);
+		int i;
+		u32 v0 = v;
 
-			for (i = 0; i < TS_IN_COUNT; i++) {
-				if (dvb->ts[i].s2p_id == 0)
-					fec_s0 = i;
-				else if (dvb->ts[i].s2p_id == 1)
-					fec_s1 = i;
-			}
-if (dsc_source == 1) {
-			invert0 = dvb->s2p[0].invert;
-			invert1 = dvb->s2p[1].invert;
-}
-			v &= ~((0x3 << S2P0_FEC_SERIAL_SEL) |
-			       (0x1f << INVERT_S2P0_FEC_CLK) |
-			       (0x3 << S2P1_FEC_SERIAL_SEL) |
-			       (0x1f << INVERT_S2P1_FEC_CLK));
-
-			v |= (fec_s0 << S2P0_FEC_SERIAL_SEL) |
-			    (invert0 << INVERT_S2P0_FEC_CLK) |
-			    (fec_s1 << S2P1_FEC_SERIAL_SEL) |
-			    (invert1 << INVERT_S2P1_FEC_CLK);
-			WRITE_MPEG_REG(STB_TOP_CONFIG, v);
+		for (i = 0; i < TS_IN_COUNT; i++) {
+		    if (dvb->ts[i].s2p_id == 0)
+			fec_s0 = i;
+		    else if (dvb->ts[i].s2p_id == 1)
+			fec_s1 = i;
 		}
+		if (dsc_source == 1) {
+		    invert0 = dvb->s2p[0].invert;
+		    invert1 = dvb->s2p[1].invert;
+		}
+		v &= ~((0x3 << S2P0_FEC_SERIAL_SEL) |
+		       (0x1f << INVERT_S2P0_FEC_CLK) |
+		       (0x3 << S2P1_FEC_SERIAL_SEL) |
+		       (0x1f << INVERT_S2P1_FEC_CLK));
 
-		/*Initialize the registers */
-		DMX_WRITE_REG(dmx->id, STB_INT_MASK, DEMUX_INT_MASK);
-		DMX_WRITE_REG(dmx->id, DEMUX_MEM_REQ_EN,
+		v |= (fec_s0 << S2P0_FEC_SERIAL_SEL) |
+		     (invert0 << INVERT_S2P0_FEC_CLK) |
+		     (fec_s1 << S2P1_FEC_SERIAL_SEL) |
+		     (invert1 << INVERT_S2P1_FEC_CLK);
+		WRITE_MPEG_REG(STB_TOP_CONFIG, v);
+		pr_dbg("cfg0:%x cfg:%x fec_s0:%x invert0:%x fec_s1:%x invert1:%x\n",
+			v0, v, fec_s0, invert0, fec_s1, invert1);
+	    }
+
+	    /*Initialize the registers */
+	    DMX_WRITE_REG(dmx->id, STB_INT_MASK, DEMUX_INT_MASK);
+	    DMX_WRITE_REG(dmx->id, DEMUX_MEM_REQ_EN,
 #ifdef USE_AHB_MODE
-			      (1 << SECTION_AHB_DMA_EN) |
-			      (0 << SUB_AHB_DMA_EN) |
-			      (1 << OTHER_PES_AHB_DMA_EN) |
+			  (1 << SECTION_AHB_DMA_EN) |
+			  (0 << SUB_AHB_DMA_EN) |
+			  (1 << OTHER_PES_AHB_DMA_EN) |
 #endif
-			      (1 << SECTION_PACKET) |
-			      (1 << VIDEO_PACKET) |
-			      (1 << AUDIO_PACKET) |
-			      (1 << SUB_PACKET) |
-			      (1 << SCR_ONLY_PACKET) |
-				(1 << OTHER_PES_PACKET));
-		DMX_WRITE_REG(dmx->id, PES_STRONG_SYNC, 0x1234);
+			  (1 << SECTION_PACKET) |
+			  (1 << VIDEO_PACKET) |
+			  (1 << AUDIO_PACKET) |
+			  (1 << SUB_PACKET) |
+			  (1 << SCR_ONLY_PACKET) |
+			  (1 << OTHER_PES_PACKET));
+	    DMX_WRITE_REG(dmx->id, PES_STRONG_SYNC, 0x1234);
+
 		DMX_WRITE_REG(dmx->id, DEMUX_ENDIAN,
+			      (1<<SEPERATE_ENDIAN) |
+			      (0<<OTHER_PES_ENDIAN) |
+			      (7<<SCR_ENDIAN) |
+			      (7<<SUB_ENDIAN) |
+			      (7<<AUDIO_ENDIAN) |
+			      (7<<VIDEO_ENDIAN) |
 			      (7 << OTHER_ENDIAN) |
 			      (7 << BYPASS_ENDIAN) | (0 << SECTION_ENDIAN));
-		DMX_WRITE_REG(dmx->id, TS_HIU_CTL,
-			      (0 << LAST_BURST_THRESHOLD) |
-			      (hi_bsf << USE_HI_BSF_INTERFACE));
+//	    DMX_WRITE_REG(dmx->id, DEMUX_ENDIAN,
+//		          (7 << OTHER_ENDIAN) |
+//			  (7 << BYPASS_ENDIAN) | (0 << SECTION_ENDIAN));
 
-		DMX_WRITE_REG(dmx->id, FEC_INPUT_CONTROL,
+	    DMX_WRITE_REG(dmx->id, TS_HIU_CTL,
+		          (0 << LAST_BURST_THRESHOLD) |
+			  (hi_bsf << USE_HI_BSF_INTERFACE));
+
+	    DMX_WRITE_REG(dmx->id, FEC_INPUT_CONTROL,
 			      (fec_core_sel << FEC_CORE_SEL) |
 			      (fec_sel << FEC_SEL) | (fec_ctrl << 0));
-		DMX_WRITE_REG(dmx->id, STB_OM_CTL,
+	    DMX_WRITE_REG(dmx->id, STB_OM_CTL,
 			      (0x40 << MAX_OM_DMA_COUNT) |
 			      (0x7f << LAST_OM_ADDR));
-		DMX_WRITE_REG(dmx->id, DEMUX_CONTROL,
+	    DMX_WRITE_REG(dmx->id, DEMUX_CONTROL,
 			      (0 << BYPASS_USE_RECODER_PATH) |
 			      (0 << INSERT_AUDIO_PES_STRONG_SYNC) |
 			      (0 << INSERT_VIDEO_PES_STRONG_SYNC) |
@@ -2239,7 +2243,6 @@ static u32 dmx_get_chan_target(struct aml_dmx *dmx, int cid)
 		}
 	}
 
-	pr_dbg("chan target: %x %x\n", type, dmx->channel[cid].pid);
 	return (type << PID_TYPE) | dmx->channel[cid].pid;
 }
 
@@ -2253,9 +2256,6 @@ static inline u32 dmx_get_chan_advance(struct aml_dmx *dmx, int cid)
 static int dmx_set_chan_regs(struct aml_dmx *dmx, int cid)
 {
 	u32 data, addr, advance, max;
-
-	pr_dbg("set channel (id:%d PID:0x%x) registers\n", cid,
-	       dmx->channel[cid].pid);
 
 	while (DMX_READ_REG(dmx->id, FM_WR_ADDR) & 0x8000)
 		udelay(1);
@@ -2279,8 +2279,6 @@ static int dmx_set_chan_regs(struct aml_dmx *dmx, int cid)
 	DMX_WRITE_REG(dmx->id, FM_WR_DATA, data);
 	DMX_WRITE_REG(dmx->id, FM_WR_ADDR, (advance << 16) | 0x8000 | addr);
 
-	pr_dbg("write fm %x:%x\n", (advance << 16) | 0x8000 | addr, data);
-
 	for (max = CHANNEL_COUNT - 1; max > 0; max--) {
 		if (dmx->channel[max].used)
 			break;
@@ -2288,8 +2286,6 @@ static int dmx_set_chan_regs(struct aml_dmx *dmx, int cid)
 
 	data = DMX_READ_REG(dmx->id, MAX_FM_COMP_ADDR) & 0xF0;
 	DMX_WRITE_REG(dmx->id, MAX_FM_COMP_ADDR, data | (max >> 1));
-
-	pr_dbg("write fm comp %x\n", data | (max >> 1));
 
 	if (DMX_READ_REG(dmx->id, OM_CMD_STATUS) & 0x8e00) {
 		pr_error("error send cmd %x\n",
@@ -2581,6 +2577,9 @@ static void reset_async_fifos(struct aml_dvb *dvb)
 		dvb->asyncfifo[i].buf_read = 0;
 	}
 
+	if (dvb->ts[0].mode == AM_TS_SERIAL)
+		dvb->dmx[0].source = AM_TS_SRC_S_TS0;
+
 	for (j = 0; j < DMX_DEV_COUNT; j++) {
 		if (!dvb->dmx[j].init)
 			continue;
@@ -2608,8 +2607,8 @@ static void reset_async_fifos(struct aml_dvb *dvb)
 				break;
 			}
 		}
-		pr_dbg("Set DMX%d TS_RECORDER_ENABLE: %s\n", dvb->dmx[j].id,
-		       record_enable ? "yes" : "no");
+		pr_dbg("Set DMX%d TS_RECORDER_ENABLE: %s mode:%d\n", dvb->dmx[j].id,
+		       record_enable ? "yes" : "no", dvb->ts[j].mode);
 		if (record_enable) {
 			/*DMX_SET_REG_MASK(dvb->dmx[j].id,
 			DEMUX_CONTROL, 1<<TS_RECORDER_ENABLE); */
@@ -3103,7 +3102,7 @@ int dmx_alloc_chan(struct aml_dmx *dmx, int type, int pes_type, int pid)
 		return -1;
 	}
 
-	pr_dbg("allocate channel(id:%d PID:0x%x)\n", id, pid);
+	pr_dbg("allocate channel(id:%d PID:%d)\n", id, pid);
 
 	if (id <= 3) {
 		ret = dmx_get_chan(dmx, pid);
@@ -3395,7 +3394,7 @@ static int dmx_add_feed(struct aml_dmx *dmx, struct dvb_demux_feed *feed)
 	case DMX_TYPE_TS:
 
 		ret = dmx_get_chan(dmx, feed->pid);
-		pr_dbg("DMX_TYPE_TS pid:0x%x, ret:%d sf_ret:%d\n", feed->pid, ret, sf_ret);
+		pr_dbg("DMX_TYPE_TS pid:%d pes:%d ret:%d sf_ret:%d\n", feed->pid, feed->pes_type, ret, sf_ret);
 		if (ret >= 0) {
 			if (DVR_FEED(dmx->channel[ret].feed)) {
 				if (DVR_FEED(feed)) {
@@ -3828,6 +3827,8 @@ int aml_dmx_hw_set_source(struct dmx_demux *demux, dmx_source_t src)
 		ret = -EINVAL;
 		break;
 	}
+	pr_dbg("src:%d hw_src:%d dmx->source:%d\n",
+						src, hw_src, dmx->source);
 
 	if (hw_src != dmx->source) {
 		dmx->source = hw_src;
@@ -3885,6 +3886,8 @@ int aml_stb_hw_set_source(struct aml_dvb *dvb, dmx_source_t src)
 		ret = -EINVAL;
 		break;
 	}
+	pr_dbg("src:%d hw_src:%d dvb->stb_source:%d\n",
+						src, hw_src, dvb->stb_source);
 
 	if (dvb->stb_source != hw_src) {
 		int old_source = dvb->stb_source;
@@ -3995,6 +3998,8 @@ int aml_tso_hw_set_source(struct aml_dvb *dvb, dmx_source_t src)
 		ret = -EINVAL;
 		break;
 	}
+	pr_dbg("src:%d hw_src:%d dvb->tso_source:%d\n",
+						src, hw_src, dvb->tso_source);
 
 	if (hw_src != dvb->tso_source) {
 		dvb->tso_source = hw_src;

--- a/drivers/amlogic/dvb-avl/aml_dvb.h
+++ b/drivers/amlogic/dvb-avl/aml_dvb.h
@@ -243,6 +243,7 @@ struct aml_dvb {
 	struct timer_list    watchdog_timer;
 	int                  dmx_watchdog_disable[DMX_DEV_COUNT];
 	struct aml_swfilter  swfilter;
+	int		     ts_out_invert;
 };
 
 

--- a/drivers/amlogic/dvb-avl/aml_fe.c
+++ b/drivers/amlogic/dvb-avl/aml_fe.c
@@ -73,6 +73,7 @@ static struct r848_config r848_config = {
 static struct avl6862_config avl6862_config = {
 	.demod_address = 0x14,
 	.tuner_address = 0x7A,
+	.ts_serial = 0,
 };
 
 int avl6862_Reset(void)
@@ -113,11 +114,13 @@ static int avl6862_fe_init(struct aml_dvb *advb, struct platform_device *pdev, s
 	pr_inf("Init AVL6862 frontend %d\n", id);
 	
 #ifdef CONFIG_OF
+	of_property_read_u32(pdev->dev.of_node, "fe0_ts", &avl6862_config.ts_serial);
+	pr_dbg("fe0_ts=%d\n", avl6862_config.ts_serial);
 	if (of_property_read_u32(pdev->dev.of_node, "dtv_demod0_i2c_adap_id", &i2c_adap_id)) {
 		ret = -ENOMEM;
 		goto err_resource;
 	}
-	pr_dbg("i2c_adap_id=%d\n", &i2c_adap_id);
+	pr_dbg("i2c_adap_id=%d\n", i2c_adap_id);
 	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_reset_gpio-gpios", 0, NULL);
 	gpio_reset = desc_to_gpio(desc);
 	pr_dbg("gpio_reset=%d\n", gpio_reset);
@@ -125,6 +128,13 @@ static int avl6862_fe_init(struct aml_dvb *advb, struct platform_device *pdev, s
 	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_power_gpio-gpios", 0, NULL);
 	gpio_power = desc_to_gpio(desc);
 	pr_dbg("gpio_power=%d\n", gpio_power);
+
+	avl6862_config.gpio_lock_led =0;
+	desc = of_get_named_gpiod_flags(pdev->dev.of_node, "dtv_demod0_lock_gpio-gpios", 0, NULL);
+	if (!PTR_RET(desc)) {
+	  avl6862_config.gpio_lock_led = desc_to_gpio(desc);
+	  pr_dbg("gpio_lock_led=%d\n", avl6862_config.gpio_lock_led);
+        }
 #endif /*CONFIG_OF*/
 
 	frontend_reset = gpio_reset;

--- a/drivers/amlogic/dvb-avl/avl6862.c
+++ b/drivers/amlogic/dvb-avl/avl6862.c
@@ -26,6 +26,7 @@
 #include <linux/init.h>
 #include <linux/string.h>
 #include <linux/bitrev.h>
+#include <linux/amlogic/aml_gpio_consumer.h>
 
 #include "dvb_frontend.h"
 #include "avl6862.h"
@@ -39,7 +40,6 @@
 MODULE_PARM_DESC(debug_avl, "\n\t\t Enable AVL demodulator debug information");
 static int debug_avl;
 module_param(debug_avl, int, 0644);
-
 
 static int avl6862_i2c_rd(struct avl6862_priv *priv, u8 *buf, int len)
 {
@@ -952,6 +952,7 @@ static int avl6862_set_dvbt(struct dvb_frontend *fe)
 }
 
 #define I2C_RPT_DIV ((0x2A)*(250000)/(240*1000))	//m_CoreFrequency_Hz 250000000
+#define uiTSFrequencyHz 270000000
 
 
 static int avl6862_set_dvbmode(struct dvb_frontend *fe,
@@ -1005,14 +1006,42 @@ static int avl6862_set_dvbmode(struct dvb_frontend *fe,
 	ret |= avl6862_WR_REG32(priv, REG_GPIO_BASE + GPIO_LNB_VOLTAGE, GPIO_0);
 
 	/* set TS mode */
-	ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_serial_caddr_offset, AVL_TS_PARALLEL);
+	if (priv->config->ts_serial) {
+		ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_serial_caddr_offset, AVL_TS_SERIAL);
+		dbg_avl("set AVL_TS_SERIAL");
+	}
+	else {
+		ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_serial_caddr_offset, AVL_TS_PARALLEL);
+		dbg_avl("set AVL_TS_PARALLEL");
+	}
+
 	ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_clock_edge_caddr_offset, AVL_MPCM_RISING);
 	ret |= avl6862_WR_REG8(priv,0x200 + rc_enable_ts_continuous_caddr_offset, AVL_TS_CONTINUOUS_ENABLE);
+	ret |= avl6862_WR_REG32(priv,0x200 + rc_ts_cntns_clk_frac_d_iaddr_offset, uiTSFrequencyHz);
+	if (priv->config->ts_serial) {
+		switch (priv->delivery_system) {
+		case SYS_DVBS:
+		case SYS_DVBS2:
+			ret |= avl6862_WR_REG32(priv,0x200 + rc_ts_cntns_clk_frac_n_iaddr_offset, uiTSFrequencyHz);
+			break;
+		case SYS_DVBT:
+		case SYS_DVBT2:
+		case SYS_DVBC_ANNEX_A:
+		case SYS_DVBC_ANNEX_B:
+		default:
+			ret |= avl6862_WR_REG32(priv,0x200 + rc_ts_cntns_clk_frac_n_iaddr_offset, uiTSFrequencyHz / 2);
+			break;
+		}
+	}
+	else
+		ret |= avl6862_WR_REG32(priv,0x200 + rc_ts_cntns_clk_frac_n_iaddr_offset, uiTSFrequencyHz / 8);
 
 	/* TS serial pin */
 	ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_serial_outpin_caddr_offset, AVL_MPSP_DATA0);
+
 	/* TS serial order */
 	ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_serial_msb_caddr_offset, AVL_MPBO_MSB);
+
 	/* TS serial sync pulse */
 	ret |= avl6862_WR_REG8(priv,0x200 + rc_ts_sync_pulse_caddr_offset, AVL_TS_SERIAL_SYNC_1_PULSE);
 	/* TS error pol */
@@ -1030,6 +1059,7 @@ static int avl6862_set_dvbmode(struct dvb_frontend *fe,
 	ret |= avl6862_WR_REG32(priv, REG_TS_OUTPUT, TS_OUTPUT_ENABLE);
 
 	/* init tuner i2c repeater */
+
 	/* hold in reset */
 	ret |= avl6862_WR_REG32(priv, 0x118000 + tuner_i2c_srst_offset, 1);
 	/* close gate */
@@ -1057,7 +1087,6 @@ static int AVL_Demod_DVBSx_Diseqc_SendModulationData(struct avl6862_priv *priv, 
 	int r = 0;
 	u32 i1 = 0;
 	u32 i2 = 0;
-	u8 pucBuffTemp[8] = {0};
 	u8 Continuousflag = 0;
 	u16 uiTempOutTh = 0;
 
@@ -1167,7 +1196,6 @@ int  AVL_Demod_DVBSx_Diseqc_SendTone(struct avl6862_priv *priv, u8 ucTone, u8 uc
 	int r = 0;
 	u32 i1 = 0;
 	u32 i2 = 0;
-	u8 pucBuffTemp[8] = {0};
 	u8 Continuousflag = 0;
 	u16 uiTempOutTh = 0;
 
@@ -1257,7 +1285,6 @@ static int avl6862_diseqc(struct dvb_frontend *fe,
 static int avl6862_burst(struct dvb_frontend *fe, enum fe_sec_mini_cmd burst)
 {
 	struct avl6862_priv *priv = fe->demodulator_priv;
-	struct AVL_Diseqc_TxStatus TxStatus;
 	int ret;
 
 	ret = avl6862_set_dvbmode(fe,SYS_DVBS);
@@ -1353,8 +1380,8 @@ static int avl6862_read_status(struct dvb_frontend *fe, enum fe_status *status)
 	int ret = 0;
 	u32 reg = 0, agc, mul, snr = 0;
 	u16 Level;
-	int i = 0;
 	int Percent = 0;
+	int lock_led = priv->config->gpio_lock_led;
 
 	switch (priv->delivery_system) {
 	case SYS_DVBC_ANNEX_A:
@@ -1433,6 +1460,9 @@ static int avl6862_read_status(struct dvb_frontend *fe, enum fe_status *status)
 		c->cnr.len = 1;
 		c->cnr.stat[0].scale = FE_SCALE_NOT_AVAILABLE;
 	}
+	if (lock_led)
+		gpio_direction_output(lock_led, snr > 1000 ? 1 : 0);
+	dbg_avl("Status:%x level:%d snr:%d", *status, Percent, snr);
 	return ret;
 }
 
@@ -1492,6 +1522,7 @@ static int avl6862_read_ber(struct dvb_frontend *fe, u32 *ber)
 	default:
 		ret = 1;
 	}
+	dbg_avl("BER:%d ret:%d", *ber, ret);
 	return ret;
 }
 
@@ -1507,7 +1538,10 @@ static int avl6862_set_frontend(struct dvb_frontend *fe)
 	struct dtv_frontend_properties *c = &fe->dtv_property_cache;
 	u32 demod_mode;
 	int ret;
+	int lock_led = priv->config->gpio_lock_led;
 
+	if (lock_led)
+		gpio_direction_output(lock_led, 0);
 
 	/* check that mode is correctly set */
 	ret = avl6862_RD_REG32(priv, 0x200 + rs_current_active_mode_iaddr_offset, &demod_mode);
@@ -1531,7 +1565,8 @@ static int avl6862_set_frontend(struct dvb_frontend *fe)
 	case SYS_DVBT2:
 		if (demod_mode != AVL_DVBTX)
 			ret = avl6862_set_dvbmode(fe, c->delivery_system);
-		if (demod_mode != AVL_DVBTX) {
+		ret = avl6862_RD_REG32(priv, 0x200 + rs_current_active_mode_iaddr_offset, &demod_mode);
+		if (ret || demod_mode != AVL_DVBTX) {
 			dev_err(&priv->i2c->dev, "%s: failed to enter DVBTx mode",
 				KBUILD_MODNAME);
 			ret = -EAGAIN;
@@ -1542,7 +1577,8 @@ static int avl6862_set_frontend(struct dvb_frontend *fe)
 	case SYS_DVBC_ANNEX_A:
 		if (demod_mode != AVL_DVBC)
 			ret = avl6862_set_dvbmode(fe, c->delivery_system);
-		if (demod_mode != AVL_DVBC) {
+		ret = avl6862_RD_REG32(priv, 0x200 + rs_current_active_mode_iaddr_offset, &demod_mode);
+		if (ret || demod_mode != AVL_DVBC) {
 			dev_err(&priv->i2c->dev, "%s: failed to enter DVBC mode",
 				KBUILD_MODNAME);
 			ret = -EAGAIN;
@@ -1553,7 +1589,8 @@ static int avl6862_set_frontend(struct dvb_frontend *fe)
 	case SYS_DVBC_ANNEX_B:
 		if (demod_mode != AVL_DVBC)
 			ret = avl6862_set_dvbmode(fe, c->delivery_system);
-		if (demod_mode != AVL_DVBC) {
+		ret = avl6862_RD_REG32(priv, 0x200 + rs_current_active_mode_iaddr_offset, &demod_mode);
+		if (ret || demod_mode != AVL_DVBC) {
 			dev_err(&priv->i2c->dev, "%s: failed to enter DVBC annex B mode",
 				KBUILD_MODNAME);
 			ret = -EAGAIN;
@@ -1565,7 +1602,8 @@ static int avl6862_set_frontend(struct dvb_frontend *fe)
 	case SYS_DVBS2:
 		if (demod_mode != AVL_DVBSX)
 			ret = avl6862_set_dvbmode(fe, c->delivery_system);
-		if (demod_mode != AVL_DVBSX) {
+		ret = avl6862_RD_REG32(priv, 0x200 + rs_current_active_mode_iaddr_offset, &demod_mode);
+		if (ret || demod_mode != AVL_DVBSX) {
 			dev_err(&priv->i2c->dev, "%s: failed to enter DVBSx mode",
 				KBUILD_MODNAME);
 			ret = -EAGAIN;
@@ -1592,7 +1630,7 @@ static int avl6862_tune(struct dvb_frontend *fe, bool re_tune,
 	}
 	return avl6862_read_status(fe, status);
 }
-
+#if 0
 static int avl6862_set_property(struct dvb_frontend *fe,
 		struct dtv_property *p)
 {
@@ -1629,7 +1667,7 @@ static int avl6862_set_property(struct dvb_frontend *fe,
 
 	return ret;
 }
-
+#endif
 static int avl6862_init(struct dvb_frontend *fe)
 {
 	return 0;
@@ -1644,6 +1682,7 @@ static void avl6862_release(struct dvb_frontend *fe)
 {
 	struct avl6862_priv *priv = fe->demodulator_priv;
 	kfree(priv);
+	return;
 }
 
 static struct dvb_frontend_ops avl6862_ops = {
@@ -1697,7 +1736,7 @@ static struct dvb_frontend_ops avl6862_ops = {
 	.get_frontend_algo		= avl6862fe_algo,
 	.tune				= avl6862_tune,
 
-//	.set_property			= avl6862_set_property,
+// 	.set_property			= NULL, // avl6862_set_property,
 	.set_frontend			= avl6862_set_frontend,
 };
 

--- a/drivers/amlogic/dvb-avl/avl6862.h
+++ b/drivers/amlogic/dvb-avl/avl6862.h
@@ -23,22 +23,7 @@
 #include "dvb_frontend.h"
 
 #define MAX_CHANNEL_INFO 256
-#if 0
-typedef struct s_DVBTx_Channel_TS
-{
-    // number, example 474*1000 is RF frequency 474MHz.
-    int channel_freq_khz;
-    // number, example 8000 is 8MHz bandwith channel.
-    int channel_bandwith_khz;
 
-    u8 channel_type;
-    // 0 - Low priority layer, 1 - High priority layer
-    u8 dvbt_hierarchy_layer;
-    // data PLP id, 0 to 255; for single PLP DVBT2 channel, this ID is 0; for DVBT channel, this ID isn't used.
-    u8 data_plp_id;
-    u8 channel_profile;
-}s_DVBTx_Channel_TS;
-#endif
 struct avl6862_priv {
 	struct i2c_adapter *i2c;
  	struct avl6862_config *config;
@@ -47,18 +32,18 @@ struct avl6862_priv {
 
 	/* DVB-Tx */
 	u16 g_nChannel_ts_total;
-//	s_DVBTx_Channel_TS global_channel_ts_table[MAX_CHANNEL_INFO];
 };
 
 struct avl6862_config {
-	int		i2c_id; // i2c adapter id
-	void	*i2c_adapter; // i2c adapter
+	int		i2c_id;        // i2c adapter id
+	void		*i2c_adapter;  // i2c adapter
 	u8		demod_address; // demodulator i2c address
 	u8		tuner_address; // tuner i2c address
-	unsigned char eDiseqcStatus;
+	unsigned char 	eDiseqcStatus;
+	int             ts_serial;
+	int		gpio_lock_led;
 };
 
 extern struct dvb_frontend *avl6862_attach(struct avl6862_config *config, struct i2c_adapter *i2c);
-extern struct dvb_frontend *avl6862x_attach(struct avl6862_config *config, struct i2c_adapter *i2c);
 
 #endif /* AVL6862_H */

--- a/drivers/amlogic/dvb-avl/c_stb_define.h
+++ b/drivers/amlogic/dvb-avl/c_stb_define.h
@@ -91,6 +91,7 @@
 /*  7:0 -- fec_sync_byte (default : 0x47)*/
 /*#define TS_TOP_CONFIG           (STB_CBUS_BASE + 0xf1) // 0x16f1*/
 /*----------- bit define -----------*/
+#define TS_OUT_CLK_INVERT	    16
 #define TS_PACKAGE_LENGTH_SUB_1     8
 #define FEC_DEFAULT_SYNC_BYTE       0
 


### PR DESCRIPTION
This PR adds support for KVIM2 VTV board in avl6862 driver. Driver was successfully tested in CoreELEC builds for KVIM2. 