### PR TITLE
meson-ir: sync timeouts with upstream kernel

### DIFF
--- a/drivers/media/rc/meson-ir.c
+++ b/drivers/media/rc/meson-ir.c
@@ -166,8 +166,8 @@ static int meson_ir_probe(struct platform_device *pdev)
 	ir->rc->allowed_protos = RC_BIT_ALL;
 	ir->rc->rx_resolution = US_TO_NS(MESON_TRATE);
 	ir->rc->min_timeout = 1;
-	ir->rc->timeout = MS_TO_NS(200);
-	ir->rc->max_timeout = MS_TO_NS(1000);
+	ir->rc->timeout = MS_TO_NS(125);
+	ir->rc->max_timeout = MS_TO_NS(1250);
 	ir->rc->driver_name = DRIVER_NAME;
 
 	spin_lock_init(&ir->lock);


### PR DESCRIPTION
Upstream uses the default timeout of 125ms and a max_timeout of 10 * 125ms.

See commit b358e747aebc4a52f20732d569ec04c6bc15d008 upstream.

This will make IR remotes a bit snappier