### PR TITLE
Allow use GPIO for IR remote receive on Odroid C2.

### DIFF
--- a/drivers/amlogic/pinctrl/pinctrl_amlogic.c
+++ b/drivers/amlogic/pinctrl/pinctrl_amlogic.c
@@ -922,6 +922,13 @@ static int meson_gpio_set_pullup_down(struct gpio_chip *chip,
 	meson_config_pullup(pin, domain, bank, config);
 	return 0;
 }
+
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	#define	AMLGPIO_IRQ_MAX	8
+
+	unsigned int meson_irq_desc[AMLGPIO_IRQ_MAX] = { 0, };
+#endif
+
 static int meson_gpio_to_irq(struct gpio_chip *chip,
 			     unsigned int gpio, unsigned gpio_flag)
 {
@@ -935,12 +942,23 @@ static int meson_gpio_to_irq(struct gpio_chip *chip,
 				0x1,	/*GPIO_IRQ_RISING*/
 				0x10001, /*GPIO_IRQ_FALLING*/
 				};
-	 /*set trigger type*/
+	/*set trigger type*/
 	struct meson_domain *domain = to_meson_domain(chip);
-	 pin = domain->data->pin_base + gpio;
-	 regmap_update_bits(int_reg, (GPIO_EDGE * 4),
-						0x10001<<irq_bank,
-						type[irq_type]<<irq_bank);
+
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	if (meson_irq_desc[irq_bank])	{
+		pr_err("ERROR(%s) : already allocation irq bank!!\n",
+							 __func__);
+		pr_err("ERROR(%s) : gpio = %d, bank = %d\n", __func__,
+							    gpio,
+							    irq_bank);
+		return	-1;
+	}
+#endif
+	pin = domain->data->pin_base + gpio;
+	regmap_update_bits(int_reg, (GPIO_EDGE * 4),
+					0x10001<<irq_bank,
+					type[irq_type]<<irq_bank);
 	/*select pin*/
 	start_bit = (irq_bank&3)*8;
 	regmap_update_bits(int_reg,
@@ -952,8 +970,14 @@ static int meson_gpio_to_irq(struct gpio_chip *chip,
 
 	regmap_update_bits(int_reg,  (GPIO_FILTER_NUM*4),
 			0x7<<start_bit, filter<<start_bit);
+
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	meson_irq_desc[irq_bank] = gpio;
+#endif
+
 	return 0;
 }
+
 static int meson_gpio_mask_irq(struct gpio_chip *chip,
 			     unsigned int gpio, unsigned gpio_flag)
 {
@@ -986,6 +1010,117 @@ static int meson_gpio_mask_irq(struct gpio_chip *chip,
 	return 0;
 }
 
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+
+#include <linux/interrupt.h>
+
+static int find_free_irq_bank(void)
+{
+	unsigned int i;
+
+	for (i = 0; i < AMLGPIO_IRQ_MAX; i++)	{
+		if (!meson_irq_desc[i])
+			break;
+	}
+
+	if (i == AMLGPIO_IRQ_MAX)
+		pr_err("ERROR(%s) : Can't find free irq bank!!\n", __func__);
+
+	return	(i != AMLGPIO_IRQ_MAX) ? i : -1;
+}
+
+/* enable sysclass gpio edge */
+static int meson_to_irq(struct gpio_chip *chip,
+			unsigned int offset)
+{
+	return	offset;
+}
+
+/* find available irq bank */
+int meson_fix_irqbank(int bank)
+{
+	if (bank < AMLGPIO_IRQ_MAX)	{
+		if (!meson_irq_desc[bank])
+			return	bank;
+		else	{
+			pr_err("ERROR(%s):already allocation irq bank(%d)!!\n",
+							__func__, bank);
+		}
+
+		/* if irq bank is not empty then find free irq bank */
+		bank = find_free_irq_bank();
+		pr_err("%s : new allocation irq bank(%d)!!\n",
+						__func__, bank);
+		return	bank;
+	}
+	return	-1;
+}
+EXPORT_SYMBOL(meson_fix_irqbank);
+
+int meson_setup_irq(struct gpio_chip *chip, unsigned int gpio,
+			unsigned int irq_flags, int *irq_banks)
+{
+	int irq_rising = -1, irq_falling = -1;
+	unsigned int gpio_flag;
+
+	/* rising irq setup */
+	if (irq_flags & IRQF_TRIGGER_RISING)	{
+		irq_rising = find_free_irq_bank();
+		if (irq_rising < 0)
+			goto out;
+
+		gpio_flag = AML_GPIO_IRQ(irq_rising,
+					 FILTER_NUM0,
+					 GPIO_IRQ_RISING);
+
+		if (meson_gpio_to_irq(chip, gpio, gpio_flag) < 0)
+			goto out;
+	}
+
+	/* falling irq setup */
+	if (irq_flags & IRQF_TRIGGER_FALLING)	{
+		irq_falling = find_free_irq_bank();
+		if ((irq_falling) < 0)
+			goto out;
+
+		gpio_flag = AML_GPIO_IRQ(irq_falling,
+					 FILTER_NUM0,
+					 GPIO_IRQ_FALLING);
+
+		if (meson_gpio_to_irq(chip, gpio, gpio_flag) < 0)
+			goto out;
+	}
+
+	irq_banks[0] = irq_rising;	irq_banks[1] = irq_falling;
+	return	0;
+out:
+	if (irq_rising  != -1)
+		meson_irq_desc[irq_rising]  = 0;
+	if (irq_falling != -1)
+		meson_irq_desc[irq_falling] = 0;
+	return	-1;
+}
+EXPORT_SYMBOL(meson_setup_irq);
+
+void meson_free_irq(unsigned int gpio, int *irq_banks)
+{
+	int i, find;
+
+	irq_banks[0] = -1, irq_banks[1] = -1;
+
+	for (i = 0, find = 0; i < AMLGPIO_IRQ_MAX; i++)	{
+		if (gpio == meson_irq_desc[i])	{
+			irq_banks[find++] = i;
+			meson_irq_desc[i] = 0;
+		}
+		if (find == 2)
+			break;
+	}
+}
+EXPORT_SYMBOL(meson_free_irq);
+
+#endif
+
 struct pinctrl_dev *pctl;
 static int meson_gpiolib_register(struct amlogic_pmx  *pc)
 {
@@ -1006,6 +1141,9 @@ static int meson_gpiolib_register(struct amlogic_pmx  *pc)
 		domain->chip.set_pullup_down = meson_gpio_set_pullup_down;
 		domain->chip.set_gpio_to_irq = meson_gpio_to_irq;
 		domain->chip.mask_gpio_irq = meson_gpio_mask_irq;
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+		domain->chip.to_irq = meson_to_irq;
+#endif
 		domain->chip.base = -1;
 		domain->chip.ngpio = domain->data->num_pins;
 		domain->chip.can_sleep = false;

--- a/drivers/gpio/gpiolib.c
+++ b/drivers/gpio/gpiolib.c
@@ -419,13 +419,21 @@ static irqreturn_t gpio_sysfs_irq(int irq, void *priv)
 	return IRQ_HANDLED;
 }
 
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	#include <linux/amlogic/pinctrl_amlogic.h>
+	/* AMLogic GPIO irq bank start offset */
+	#define	AMLGPIO_IRQ_BASE	96
+#endif
+
 static int gpio_setup_irq(struct gpio_desc *desc, struct device *dev,
 		unsigned long gpio_flags)
 {
 	struct kernfs_node	*value_sd;
 	unsigned long		irq_flags;
 	int			ret, irq, id;
-
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	int			irq_banks[2] = {0, };
+#endif
 	if ((desc->flags & GPIO_TRIGGER_MASK) == gpio_flags)
 		return 0;
 
@@ -435,8 +443,21 @@ static int gpio_setup_irq(struct gpio_desc *desc, struct device *dev,
 
 	id = desc->flags >> ID_SHIFT;
 	value_sd = idr_find(&dirent_idr, id);
-	if (value_sd)
+	if (value_sd)	{
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+		meson_free_irq(irq, &irq_banks[0]);
+
+		/* rising irq bank */
+		if (irq_banks[0] != -1)
+			free_irq(irq_banks[0] + AMLGPIO_IRQ_BASE, value_sd);
+
+		/* falling irq bank */
+		if (irq_banks[1] != -1)
+			free_irq(irq_banks[1] + AMLGPIO_IRQ_BASE, value_sd);
+#else
 		free_irq(irq, value_sd);
+#endif
+	}
 
 	desc->flags &= ~GPIO_TRIGGER_MASK;
 
@@ -475,8 +496,37 @@ static int gpio_setup_irq(struct gpio_desc *desc, struct device *dev,
 		}
 	}
 
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	ret = meson_setup_irq(desc->chip, irq, irq_flags, &irq_banks[0]);
+
+	if (ret < 0)
+		goto free_id;
+
+	/* rising irq bank */
+	if (irq_banks[0] != -1)	{
+		ret = request_any_context_irq(irq_banks[0] + AMLGPIO_IRQ_BASE,
+					gpio_sysfs_irq, IRQF_DISABLED,
+					"gpiolib", value_sd);
+		if (ret < 0)
+			goto free_id;
+	}
+	/* falling irq bank */
+	if (irq_banks[1] != -1)	{
+		ret = request_any_context_irq(irq_banks[1] + AMLGPIO_IRQ_BASE,
+					gpio_sysfs_irq, IRQF_DISABLED,
+					"gpiolib", value_sd);
+
+		if (ret < 0)	{
+			if (irq_banks[0] != -1)
+				free_irq(irq_banks[0] + AMLGPIO_IRQ_BASE,
+					 value_sd);
+			goto free_id;
+		}
+	}
+#else
 	ret = request_any_context_irq(irq, gpio_sysfs_irq, irq_flags,
 				"gpiolib", value_sd);
+#endif
 	if (ret < 0)
 		goto free_id;
 

--- a/drivers/media/rc/Kconfig
+++ b/drivers/media/rc/Kconfig
@@ -342,4 +342,14 @@ config RC_ST
 
 	 If you're not sure, select N here.
 
+config IR_GPIOPLUG_CIR
+	tristate "GPIOPLUG IR remote control"
+	depends on RC_CORE
+	select IR_GPIO_CIR
+	---help---
+	   Say Y if you want to use GPIOPLUG based IR Receiver.
+
+	   To compile this driver as a module, choose M here: the module will
+	   be called gpio-ir-recv.
+
 endif #RC_DEVICES

--- a/drivers/media/rc/Makefile
+++ b/drivers/media/rc/Makefile
@@ -29,6 +29,7 @@ obj-$(CONFIG_IR_STREAMZAP) += streamzap.o
 obj-$(CONFIG_IR_WINBOND_CIR) += winbond-cir.o
 obj-$(CONFIG_RC_LOOPBACK) += rc-loopback.o
 obj-$(CONFIG_IR_GPIO_CIR) += gpio-ir-recv.o
+obj-$(CONFIG_IR_GPIOPLUG_CIR) += gpioplug-ir-recv.o
 obj-$(CONFIG_IR_IGUANA) += iguanair.o
 obj-$(CONFIG_IR_TTUSBIR) += ttusbir.o
 obj-$(CONFIG_RC_ST) += st_rc.o

--- a/drivers/media/rc/gpioplug-ir-recv.c
+++ b/drivers/media/rc/gpioplug-ir-recv.c
@@ -1,0 +1,90 @@
+/*
+ * Pluggable GPIO IR receiver
+ *
+ * Copyright (c) 2015 Dongjin Kim (tobetter@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/gpio.h>
+#include <linux/slab.h>
+#include <linux/platform_device.h>
+#include <media/gpio-ir-recv.h>
+
+static unsigned gpio_nr = -1;
+module_param(gpio_nr, uint, 0);
+MODULE_PARM_DESC(gpio_nr, "GPIO number to receive IR pulse");
+
+static bool active_low = 1;
+module_param(active_low, bool, 0);
+MODULE_PARM_DESC(active_low,
+		"IR pulse trigger level, (1=low active, 0=high active");
+
+static struct platform_device *pdev;
+static struct gpio_ir_recv_platform_data *pdata;
+
+static int __init gpio_init(void)
+{
+	int rc = -ENOMEM;
+
+	if (gpio_nr == -1) {
+		pr_err("gpioplug-ir-recv: missing module parameter: 'gpio_nr'\n");
+		return -EINVAL;
+	}
+
+	pdev = platform_device_alloc(GPIO_IR_DRIVER_NAME, -1);
+	if (!pdev)
+		return rc;
+
+	pdata = kzalloc(sizeof(*pdata), GFP_KERNEL);
+	if (!pdata)
+		goto err_free_platform_data;
+
+	pdev->dev.platform_data = pdata;
+
+	pdata->gpio_nr = gpio_nr;
+	pdata->active_low = active_low;
+	pdata->allowed_protos = 0;
+	pdata->map_name = NULL;
+
+	rc = platform_device_add(pdev);
+	if (rc < 0)
+		goto err_free_device;
+
+	dev_info(&pdev->dev,
+		"IR driver is initialized (gpio_nr=%d, pulse level=%s)\n",
+		pdata->gpio_nr, pdata->active_low ? "low" : "high");
+
+	return 0;
+
+err_free_platform_data:
+	kfree(pdata);
+
+err_free_device:
+	platform_device_put(pdev);
+
+	return rc;
+}
+
+static void __exit gpio_exit(void)
+{
+	dev_info(&pdev->dev, "gpioplug-ir-recv: IR driver is removed\n");
+	platform_device_unregister(pdev);
+}
+
+MODULE_DESCRIPTION("GPIO IR Receiver driver");
+MODULE_LICENSE("GPL v2");
+
+module_init(gpio_init);
+module_exit(gpio_exit);

--- a/include/linux/amlogic/pinctrl_amlogic.h
+++ b/include/linux/amlogic/pinctrl_amlogic.h
@@ -193,4 +193,11 @@ static inline struct meson_domain *to_meson_domain(struct gpio_chip *chip)
 }
 
 extern struct amlogic_pmx *gl_pmx;
+
+#if defined(CONFIG_ARCH_MESON64_ODROIDC2)
+	int meson_setup_irq(struct gpio_chip *chip, unsigned int gpio,
+				unsigned int irq_flags, int *irq_banks);
+	int meson_fix_irqbank(int bank);
+	void meson_free_irq(unsigned int gpio, int *irq_banks);
+#endif
 #endif

--- a/include/media/gpio-ir-recv.h
+++ b/include/media/gpio-ir-recv.h
@@ -13,6 +13,9 @@
 #ifndef __GPIO_IR_RECV_H__
 #define __GPIO_IR_RECV_H__
 
+#define GPIO_IR_DRIVER_NAME	"gpio-rc-recv"
+#define GPIO_IR_DEVICE_NAME	"gpio_ir_recv"
+
 struct gpio_ir_recv_platform_data {
 	int		gpio_nr;
 	bool		active_low;


### PR DESCRIPTION
gpioplug-ir-recv is module, officially supported by Hardkernel to allow receive IR from remote through IR diode connected to the GPIO pins (together with gpio-ir-recv, which is already present on LibreELEC).
https://wiki.odroid.com/odroid-c2/application_note/gpio/ir
Cherrypicking from https://github.com/CoreELEC/CoreELEC/commit/ea9418866dfe57ea9a29ae8cdb987d28ab556fba#diff-074cff09e0ea1d619a75074d7940de22.

Needed for https://github.com/LibreELEC/LibreELEC.tv/pull/3206