### PR TITLE
Allow use GPIO for IR remote receive on Odroid C2.

### DIFF
--- a/drivers/media/common/siano/smsir.h
+++ b/drivers/media/common/siano/smsir.h
@@ -30,8 +30,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <linux/input.h>
 #include <media/rc-core.h>
 
-#define IR_DEFAULT_TIMEOUT		100
-
 struct smscore_device_t;
 
 struct ir_t {

--- a/drivers/media/rc/Kconfig
+++ b/drivers/media/rc/Kconfig
@@ -342,4 +342,14 @@ config RC_ST
 
 	 If you're not sure, select N here.
 
+config IR_GPIOPLUG_CIR
+	tristate "GPIOPLUG IR remote control"
+	depends on RC_CORE
+	select IR_GPIO_CIR
+	---help---
+	   Say Y if you want to use GPIOPLUG based IR Receiver.
+
+	   To compile this driver as a module, choose M here: the module will
+	   be called gpio-ir-recv.
+
 endif #RC_DEVICES

--- a/drivers/media/rc/Makefile
+++ b/drivers/media/rc/Makefile
@@ -29,6 +29,7 @@ obj-$(CONFIG_IR_STREAMZAP) += streamzap.o
 obj-$(CONFIG_IR_WINBOND_CIR) += winbond-cir.o
 obj-$(CONFIG_RC_LOOPBACK) += rc-loopback.o
 obj-$(CONFIG_IR_GPIO_CIR) += gpio-ir-recv.o
+obj-$(CONFIG_IR_GPIOPLUG_CIR) += gpioplug-ir-recv.o
 obj-$(CONFIG_IR_IGUANA) += iguanair.o
 obj-$(CONFIG_IR_TTUSBIR) += ttusbir.o
 obj-$(CONFIG_RC_ST) += st_rc.o

--- a/drivers/media/rc/gpio-ir-recv.c
+++ b/drivers/media/rc/gpio-ir-recv.c
@@ -159,7 +159,7 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
 	rcdev->input_id.version = 0x0100;
 	rcdev->dev.parent = &pdev->dev;
 	rcdev->driver_name = GPIO_IR_DRIVER_NAME;
-	rcdev->min_timeout = 0;
+	rcdev->min_timeout = 1;
 	rcdev->timeout = IR_DEFAULT_TIMEOUT;
 	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
 	if (pdata->allowed_protos)

--- a/drivers/media/rc/gpio-ir-recv.c
+++ b/drivers/media/rc/gpio-ir-recv.c
@@ -23,8 +23,6 @@
 #include <media/rc-core.h>
 #include <media/gpio-ir-recv.h>
 
-#define GPIO_IR_DRIVER_NAME	"gpio-rc-recv"
-#define GPIO_IR_DEVICE_NAME	"gpio_ir_recv"
 
 struct gpio_rc_dev {
 	struct rc_dev *rcdev;

--- a/drivers/media/rc/gpio-ir-recv.c
+++ b/drivers/media/rc/gpio-ir-recv.c
@@ -30,6 +30,7 @@ struct gpio_rc_dev {
 	struct rc_dev *rcdev;
 	int gpio_nr;
 	bool active_low;
+	struct timer_list flush_timer;
 };
 
 #ifdef CONFIG_OF
@@ -93,10 +94,24 @@ static irqreturn_t gpio_ir_recv_irq(int irq, void *dev_id)
 	if (rc < 0)
 		goto err_get_value;
 
+	mod_timer(&gpio_dev->flush_timer,
+		  jiffies + nsecs_to_jiffies(gpio_dev->rcdev->timeout));
+
 	ir_raw_event_handle(gpio_dev->rcdev);
 
 err_get_value:
 	return IRQ_HANDLED;
+}
+
+static void flush_timer(unsigned long arg)
+{
+	struct gpio_rc_dev *gpio_dev = (struct gpio_rc_dev *)arg;
+	DEFINE_IR_RAW_EVENT(ev);
+
+	ev.timeout = true;
+	ev.duration = gpio_dev->rcdev->timeout;
+	ir_raw_event_store(gpio_dev->rcdev, &ev);
+	ir_raw_event_handle(gpio_dev->rcdev);
 }
 
 static int gpio_ir_recv_probe(struct platform_device *pdev)
@@ -144,6 +159,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
 	rcdev->input_id.version = 0x0100;
 	rcdev->dev.parent = &pdev->dev;
 	rcdev->driver_name = GPIO_IR_DRIVER_NAME;
+	rcdev->min_timeout = 0;
+	rcdev->timeout = IR_DEFAULT_TIMEOUT;
+	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
 	if (pdata->allowed_protos)
 		rcdev->allowed_protos = pdata->allowed_protos;
 	else
@@ -153,6 +171,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
 	gpio_dev->rcdev = rcdev;
 	gpio_dev->gpio_nr = pdata->gpio_nr;
 	gpio_dev->active_low = pdata->active_low;
+
+	setup_timer(&gpio_dev->flush_timer, flush_timer,
+		    (unsigned long)gpio_dev);
 
 	rc = gpio_request(pdata->gpio_nr, "gpio-ir-recv");
 	if (rc < 0)
@@ -196,6 +217,7 @@ static int gpio_ir_recv_remove(struct platform_device *pdev)
 	struct gpio_rc_dev *gpio_dev = platform_get_drvdata(pdev);
 
 	free_irq(gpio_to_irq(gpio_dev->gpio_nr), gpio_dev);
+	del_timer_sync(&gpio_dev->flush_timer);
 	rc_unregister_device(gpio_dev->rcdev);
 	gpio_free(gpio_dev->gpio_nr);
 	kfree(gpio_dev);

--- a/drivers/media/rc/gpioplug-ir-recv.c
+++ b/drivers/media/rc/gpioplug-ir-recv.c
@@ -1,0 +1,90 @@
+/*
+ * Pluggable GPIO IR receiver
+ *
+ * Copyright (c) 2015 Dongjin Kim (tobetter@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/gpio.h>
+#include <linux/slab.h>
+#include <linux/platform_device.h>
+#include <media/gpio-ir-recv.h>
+
+static unsigned gpio_nr = -1;
+module_param(gpio_nr, uint, 0);
+MODULE_PARM_DESC(gpio_nr, "GPIO number to receive IR pulse");
+
+static bool active_low = 1;
+module_param(active_low, bool, 0);
+MODULE_PARM_DESC(active_low,
+		"IR pulse trigger level, (1=low active, 0=high active");
+
+static struct platform_device *pdev;
+static struct gpio_ir_recv_platform_data *pdata;
+
+static int __init gpio_init(void)
+{
+	int rc = -ENOMEM;
+
+	if (gpio_nr == -1) {
+		pr_err("gpioplug-ir-recv: missing module parameter: 'gpio_nr'\n");
+		return -EINVAL;
+	}
+
+	pdev = platform_device_alloc(GPIO_IR_DRIVER_NAME, -1);
+	if (!pdev)
+		return rc;
+
+	pdata = kzalloc(sizeof(*pdata), GFP_KERNEL);
+	if (!pdata)
+		goto err_free_platform_data;
+
+	pdev->dev.platform_data = pdata;
+
+	pdata->gpio_nr = gpio_nr;
+	pdata->active_low = active_low;
+	pdata->allowed_protos = 0;
+	pdata->map_name = NULL;
+
+	rc = platform_device_add(pdev);
+	if (rc < 0)
+		goto err_free_device;
+
+	dev_info(&pdev->dev,
+		"IR driver is initialized (gpio_nr=%d, pulse level=%s)\n",
+		pdata->gpio_nr, pdata->active_low ? "low" : "high");
+
+	return 0;
+
+err_free_platform_data:
+	kfree(pdata);
+
+err_free_device:
+	platform_device_put(pdev);
+
+	return rc;
+}
+
+static void __exit gpio_exit(void)
+{
+	dev_info(&pdev->dev, "gpioplug-ir-recv: IR driver is removed\n");
+	platform_device_unregister(pdev);
+}
+
+MODULE_DESCRIPTION("GPIO IR Receiver driver");
+MODULE_LICENSE("GPL v2");
+
+module_init(gpio_init);
+module_exit(gpio_exit);

--- a/include/media/gpio-ir-recv.h
+++ b/include/media/gpio-ir-recv.h
@@ -13,6 +13,9 @@
 #ifndef __GPIO_IR_RECV_H__
 #define __GPIO_IR_RECV_H__
 
+#define GPIO_IR_DRIVER_NAME	"gpio-rc-recv"
+#define GPIO_IR_DEVICE_NAME	"gpio_ir_recv"
+
 struct gpio_ir_recv_platform_data {
 	int		gpio_nr;
 	bool		active_low;

--- a/include/media/rc-core.h
+++ b/include/media/rc-core.h
@@ -194,7 +194,7 @@ static inline void init_ir_raw_event(struct ir_raw_event *ev)
 	memset(ev, 0, sizeof(*ev));
 }
 
-#define IR_MAX_DURATION         0xFFFFFFFF      /* a bit more than 4 seconds */
+#define IR_MAX_DURATION         500000000	/* 500 ms */
 #define US_TO_NS(usec)		((usec) * 1000)
 #define MS_TO_US(msec)		((msec) * 1000)
 #define MS_TO_NS(msec)		((msec) * 1000 * 1000)

--- a/include/media/rc-core.h
+++ b/include/media/rc-core.h
@@ -194,6 +194,7 @@ static inline void init_ir_raw_event(struct ir_raw_event *ev)
 	memset(ev, 0, sizeof(*ev));
 }
 
+#define IR_DEFAULT_TIMEOUT	MS_TO_NS(125)
 #define IR_MAX_DURATION         500000000	/* 500 ms */
 #define US_TO_NS(usec)		((usec) * 1000)
 #define MS_TO_US(msec)		((msec) * 1000)


### PR DESCRIPTION
- Adding gpioplug-ir-recv is module to allow receive IR from remote through IR diode connected to the GPIO pins (together with gpio-ir-recv, which is already present on LibreELEC). Without gpioplug [is not possible](https://forum.odroid.com/viewtopic.php?f=135&t=33357&p=242899#p242899) to use IR RX through GPIO. Gpioplug-ir-recv is originated by Cloudshell, and later on taken by HK developers as officialy supported method to support IR GPIO receive: [1](https://wiki.odroid.com/odroid-c2/application_note/gpio/ir) / [2](https://wiki.odroid.com/odroid-c2/application_note/gpio/ir/lirc_gpioir_ubuntu16.04) / [3](https://wiki.odroid.com/odroid-c2/application_note/gpio/ir/lirc_gpioir_ubuntu18.04)
Cherrypicking from https://github.com/CoreELEC/linux-amlogic/compare/03f89a8aa6c1b3f69f693cbf2ed8d300f4fc1c67...9d8ccf486c84ce33f38fc9accf5bfe4032d1d5ea.

- backporting the flush timer for gpio-ir-recv

Needed for LibreELEC/LibreELEC.tv#3206